### PR TITLE
[KV cache] Decoupled per-group page sizes for hybrid models (experimental, opt-in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -252,3 +252,7 @@ vllm/grpc/vllm_engine_pb2.pyi
 
 # Ignore generated cpu headers 
 csrc/cpu/cpu_attn_dispatch_generated.h
+
+# Humanize RLCR loop + working artifacts (not for commit)
+.humanize*
+.current-work/

--- a/tests/v1/core/test_atomic_chunk_alloc.py
+++ b/tests/v1/core/test_atomic_chunk_alloc.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Atomic multi-chunk allocation and allocator satisfiability (AC-4).
+
+* ``BlockPool.get_new_chunks`` must be all-or-nothing: a batch that cannot be
+  fully satisfied leaves the free count and every ref count exactly as before.
+* ``can_allocate_chunks`` reports whether a given ``(order, count)`` demand can
+  be carved from the current free structure, so admission can reject
+  fragmentation-infeasible requests up front.
+"""
+
+import pytest
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_can_allocate_chunks_counts_splittable_capacity():
+    blocks = [KVCacheBlock(i) for i in range(8)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2, on_evict=None)
+    # Fresh pool: two order-2 chunks (starts 0 and 4).
+    assert q.can_allocate_chunks(2, 2)
+    assert not q.can_allocate_chunks(2, 3)
+    # Each order-2 chunk splits into two order-1 chunks -> 4 total.
+    assert q.can_allocate_chunks(1, 4)
+    assert not q.can_allocate_chunks(1, 5)
+    # ... and into eight order-0 base blocks.
+    assert q.can_allocate_chunks(0, 8)
+    assert not q.can_allocate_chunks(0, 9)
+    # Out-of-range order is never satisfiable.
+    assert not q.can_allocate_chunks(3, 1)
+
+
+def test_can_allocate_demands_joint_and_threshold():
+    blocks = [KVCacheBlock(i) for i in range(8)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2, on_evict=None)
+    # Fresh: two order-2 chunks = 8 base blocks.
+    assert q.can_allocate_demands({2: 2})
+    assert not q.can_allocate_demands({2: 3})
+    # Mixed orders compete for the same base blocks: one order-2 (4 base) plus
+    # 4 order-0 == 8 fits; one more base block does not.
+    assert q.can_allocate_demands({2: 1, 0: 4})
+    assert not q.can_allocate_demands({2: 1, 0: 5})
+    assert q.can_allocate_demands({1: 1, 0: 6})
+    assert q.can_allocate_demands({})
+
+
+def test_can_allocate_demands_rejects_fragmentation():
+    blocks = [KVCacheBlock(i) for i in range(8)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2, on_evict=None)
+    held = [q.alloc_chunk(order=0) for _ in range(8)]  # allocate all base blocks
+    # Free only even-id blocks; their odd buddies remain allocated so nothing
+    # coalesces -> four scattered order-0 free blocks, no order-1 chunk exists.
+    for b in held:
+        if b.block_id % 2 == 0:
+            q.append(b)
+    assert q.num_free_blocks == 4
+    # Enough raw base blocks for an order-0 demand...
+    assert q.can_allocate_demands({0: 4})
+    assert not q.can_allocate_demands({0: 5})
+    # ...but a single order-1 chunk cannot be formed despite 4 free base
+    # blocks: fragmentation is rejected up front.
+    assert not q.can_allocate_demands({1: 1})
+
+
+def test_larger_span_first_avoids_heuristic_allocation_failure():
+    """A feasible mixed-span demand can fail if the smaller span is allocated
+    first (the uncached-first heuristic splits the only large uncached chunk),
+    but succeeds when the larger span is allocated first. This is why the
+    coordinator allocates larger-span groups first."""
+    from vllm.v1.core.kv_cache_utils import (
+        BlockHash,
+        make_block_hash_with_group_id,
+    )
+
+    def build():
+        # Drain the pool to exactly {cached order-0 chunk id0, uncached
+        # order-2 chunk 4..7}, with no uncached small chunks.
+        blocks = [KVCacheBlock(i) for i in range(8)]
+        q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2, on_evict=lambda b: True)
+        a = q.alloc_chunk(order=2)  # holds chunk 0..3
+        b = q.alloc_chunk(order=2)  # holds chunk 4..7
+        q.append(a)  # free 0..3 back (uncached order 2)
+        z = q.alloc_chunk(order=0)  # split 0..3 -> id0, leaving id1, id2..3
+        z.block_hash = make_block_hash_with_group_id(BlockHash(b"\x09" * 32), 0)
+        q.append(z)  # cached order-0 id0 (preserved, not coalesced)
+        q.alloc_chunk(order=0)  # hold id1
+        q.alloc_chunk(order=1)  # hold id2..3
+        q.append(b)  # free 4..7 back (uncached order 2)
+        return q
+
+    # Smaller-span first: order-0 splits the only order-2 chunk, order-2 fails.
+    q1 = build()
+    q1.alloc_chunk(order=0)
+    with pytest.raises(ValueError):
+        q1.alloc_chunk(order=2)
+
+    # Larger-span first: both succeed (order-0 falls back to evicting cached).
+    q2 = build()
+    big = q2.alloc_chunk(order=2)
+    small = q2.alloc_chunk(order=0)
+    assert big.block_id == 4
+    assert small.block_id == 0
+
+
+def test_get_new_chunks_is_atomic_on_failure(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    pool = BlockPool(
+        num_gpu_blocks=8, enable_caching=True, hash_block_size=1, max_allocation_span=4
+    )
+
+    free_before = pool.get_num_free_blocks()
+    refs_before = [b.ref_cnt for b in pool.blocks]
+
+    # Request far more span-4 blocks than the pool can ever provide; the
+    # batch must fail and roll back completely.
+    with pytest.raises((ValueError, RuntimeError)):
+        pool.get_new_blocks(num_blocks=100, base_span=4)
+
+    assert pool.get_num_free_blocks() == free_before
+    assert [b.ref_cnt for b in pool.blocks] == refs_before
+
+
+def test_get_new_chunks_success_then_free_roundtrips(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    pool = BlockPool(
+        num_gpu_blocks=8, enable_caching=True, hash_block_size=1, max_allocation_span=4
+    )
+
+    free_before = pool.get_num_free_blocks()
+    chunks = pool.get_new_blocks(1, base_span=2)
+    assert len(chunks) == 1
+    assert chunks[0].ref_cnt == 1
+    # One span-2 block consumes 2 base blocks.
+    assert pool.get_num_free_blocks() == free_before - 2
+    pool.free_blocks(chunks)
+    assert pool.get_num_free_blocks() == free_before
+    assert chunks[0].ref_cnt == 0
+
+
+def test_free_blocks_prepend_roundtrips_in_buddy_mode(monkeypatch):
+    """Regression: BlockPool.free_blocks(..., prepend=True) — used by
+    remove_skipped_blocks for mamba/SWA scratch recycling — must work under the
+    buddy allocator. The buddy queue previously lacked prepend_n, so this path
+    raised AttributeError and killed the engine whenever it was hit (e.g. with
+    prefix caching disabled)."""
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    pool = BlockPool(
+        num_gpu_blocks=8, enable_caching=True, hash_block_size=1, max_allocation_span=4
+    )
+    free_before = pool.get_num_free_blocks()
+    chunks = pool.get_new_blocks(1, base_span=2)
+    assert pool.get_num_free_blocks() == free_before - 2
+    # The prepend=True path that used to crash the buddy allocator.
+    pool.free_blocks(chunks, prepend=True)
+    assert pool.get_num_free_blocks() == free_before
+    assert chunks[0].ref_cnt == 0

--- a/tests/v1/core/test_atomic_chunk_alloc.py
+++ b/tests/v1/core/test_atomic_chunk_alloc.py
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Atomic multi-chunk allocation and allocator satisfiability (AC-4).
 
-* ``BlockPool.get_new_chunks`` must be all-or-nothing: a batch that cannot be
+* ``BlockPool.get_new_blocks`` must be all-or-nothing: a batch that cannot be
   fully satisfied leaves the free count and every ref count exactly as before.
-* ``can_allocate_chunks`` reports whether a given ``(order, count)`` demand can
+* ``BlockAllocator.can_allocate`` reports whether a ``{span: count}`` demand can
   be carved from the current free structure, so admission can reject
   fragmentation-infeasible requests up front.
 """
@@ -12,101 +12,66 @@
 import pytest
 
 from vllm.v1.core.block_pool import BlockPool
-from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+from vllm.v1.core.buddy_free_queue import BuddyAllocator
+from vllm.v1.core.eviction_policy import LRUEvictionPolicy
 from vllm.v1.core.kv_cache_utils import KVCacheBlock
 
 pytestmark = pytest.mark.cpu_test
 
 
-def test_can_allocate_chunks_counts_splittable_capacity():
-    blocks = [KVCacheBlock(i) for i in range(8)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2, on_evict=None)
+def _buddy(n, max_order):
+    return BuddyAllocator(
+        [KVCacheBlock(i) for i in range(n)],
+        max_order=max_order,
+        evictor=LRUEvictionPolicy(),
+    )
+
+
+def test_can_allocate_counts_splittable_capacity():
+    q = _buddy(8, max_order=2)
     # Fresh pool: two order-2 chunks (starts 0 and 4).
-    assert q.can_allocate_chunks(2, 2)
-    assert not q.can_allocate_chunks(2, 3)
+    assert q.can_allocate({4: 2})
+    assert not q.can_allocate({4: 3})
     # Each order-2 chunk splits into two order-1 chunks -> 4 total.
-    assert q.can_allocate_chunks(1, 4)
-    assert not q.can_allocate_chunks(1, 5)
+    assert q.can_allocate({2: 4})
+    assert not q.can_allocate({2: 5})
     # ... and into eight order-0 base blocks.
-    assert q.can_allocate_chunks(0, 8)
-    assert not q.can_allocate_chunks(0, 9)
-    # Out-of-range order is never satisfiable.
-    assert not q.can_allocate_chunks(3, 1)
+    assert q.can_allocate({1: 8})
+    assert not q.can_allocate({1: 9})
+    # Out-of-range span is never satisfiable.
+    assert not q.can_allocate({8: 1})
 
 
-def test_can_allocate_demands_joint_and_threshold():
-    blocks = [KVCacheBlock(i) for i in range(8)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2, on_evict=None)
+def test_can_allocate_joint_and_threshold():
+    q = _buddy(8, max_order=2)
     # Fresh: two order-2 chunks = 8 base blocks.
-    assert q.can_allocate_demands({2: 2})
-    assert not q.can_allocate_demands({2: 3})
-    # Mixed orders compete for the same base blocks: one order-2 (4 base) plus
-    # 4 order-0 == 8 fits; one more base block does not.
-    assert q.can_allocate_demands({2: 1, 0: 4})
-    assert not q.can_allocate_demands({2: 1, 0: 5})
-    assert q.can_allocate_demands({1: 1, 0: 6})
-    assert q.can_allocate_demands({})
+    assert q.can_allocate({4: 2})
+    assert not q.can_allocate({4: 3})
+    # Mixed spans compete for the same base blocks: one span-4 (4 base) plus
+    # 4 span-1 == 8 fits; one more base block does not.
+    assert q.can_allocate({4: 1, 1: 4})
+    assert not q.can_allocate({4: 1, 1: 5})
+    assert q.can_allocate({2: 1, 1: 6})
+    assert q.can_allocate({})
 
 
-def test_can_allocate_demands_rejects_fragmentation():
-    blocks = [KVCacheBlock(i) for i in range(8)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2, on_evict=None)
-    held = [q.alloc_chunk(order=0) for _ in range(8)]  # allocate all base blocks
+def test_can_allocate_rejects_fragmentation():
+    q = _buddy(8, max_order=2)
+    held = [q.allocate(1) for _ in range(8)]  # allocate all base blocks
     # Free only even-id blocks; their odd buddies remain allocated so nothing
     # coalesces -> four scattered order-0 free blocks, no order-1 chunk exists.
     for b in held:
         if b.block_id % 2 == 0:
-            q.append(b)
+            q.free(b)
     assert q.num_free_blocks == 4
-    # Enough raw base blocks for an order-0 demand...
-    assert q.can_allocate_demands({0: 4})
-    assert not q.can_allocate_demands({0: 5})
-    # ...but a single order-1 chunk cannot be formed despite 4 free base
-    # blocks: fragmentation is rejected up front.
-    assert not q.can_allocate_demands({1: 1})
+    # Enough raw base blocks for a span-1 demand...
+    assert q.can_allocate({1: 4})
+    assert not q.can_allocate({1: 5})
+    # ...but a single span-2 chunk cannot be formed despite 4 free base blocks.
+    assert not q.can_allocate({2: 1})
 
 
-def test_larger_span_first_avoids_heuristic_allocation_failure():
-    """A feasible mixed-span demand can fail if the smaller span is allocated
-    first (the uncached-first heuristic splits the only large uncached chunk),
-    but succeeds when the larger span is allocated first. This is why the
-    coordinator allocates larger-span groups first."""
-    from vllm.v1.core.kv_cache_utils import (
-        BlockHash,
-        make_block_hash_with_group_id,
-    )
-
-    def build():
-        # Drain the pool to exactly {cached order-0 chunk id0, uncached
-        # order-2 chunk 4..7}, with no uncached small chunks.
-        blocks = [KVCacheBlock(i) for i in range(8)]
-        q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2, on_evict=lambda b: True)
-        a = q.alloc_chunk(order=2)  # holds chunk 0..3
-        b = q.alloc_chunk(order=2)  # holds chunk 4..7
-        q.append(a)  # free 0..3 back (uncached order 2)
-        z = q.alloc_chunk(order=0)  # split 0..3 -> id0, leaving id1, id2..3
-        z.block_hash = make_block_hash_with_group_id(BlockHash(b"\x09" * 32), 0)
-        q.append(z)  # cached order-0 id0 (preserved, not coalesced)
-        q.alloc_chunk(order=0)  # hold id1
-        q.alloc_chunk(order=1)  # hold id2..3
-        q.append(b)  # free 4..7 back (uncached order 2)
-        return q
-
-    # Smaller-span first: order-0 splits the only order-2 chunk, order-2 fails.
-    q1 = build()
-    q1.alloc_chunk(order=0)
-    with pytest.raises(ValueError):
-        q1.alloc_chunk(order=2)
-
-    # Larger-span first: both succeed (order-0 falls back to evicting cached).
-    q2 = build()
-    big = q2.alloc_chunk(order=2)
-    small = q2.alloc_chunk(order=0)
-    assert big.block_id == 4
-    assert small.block_id == 0
-
-
-def test_get_new_chunks_is_atomic_on_failure(monkeypatch):
+def test_get_new_blocks_is_atomic_on_failure(monkeypatch):
     monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
     pool = BlockPool(
         num_gpu_blocks=8, enable_caching=True, hash_block_size=1, max_allocation_span=4
@@ -124,7 +89,7 @@ def test_get_new_chunks_is_atomic_on_failure(monkeypatch):
     assert [b.ref_cnt for b in pool.blocks] == refs_before
 
 
-def test_get_new_chunks_success_then_free_roundtrips(monkeypatch):
+def test_get_new_blocks_success_then_free_roundtrips(monkeypatch):
     monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
     pool = BlockPool(
         num_gpu_blocks=8, enable_caching=True, hash_block_size=1, max_allocation_span=4
@@ -144,9 +109,8 @@ def test_get_new_chunks_success_then_free_roundtrips(monkeypatch):
 def test_free_blocks_prepend_roundtrips_in_buddy_mode(monkeypatch):
     """Regression: BlockPool.free_blocks(..., prepend=True) — used by
     remove_skipped_blocks for mamba/SWA scratch recycling — must work under the
-    buddy allocator. The buddy queue previously lacked prepend_n, so this path
-    raised AttributeError and killed the engine whenever it was hit (e.g. with
-    prefix caching disabled)."""
+    buddy allocator (which has no global reuse ordering and treats prefer_reuse
+    as a hint)."""
     monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
     pool = BlockPool(
         num_gpu_blocks=8, enable_caching=True, hash_block_size=1, max_allocation_span=4
@@ -154,7 +118,6 @@ def test_free_blocks_prepend_roundtrips_in_buddy_mode(monkeypatch):
     free_before = pool.get_num_free_blocks()
     chunks = pool.get_new_blocks(1, base_span=2)
     assert pool.get_num_free_blocks() == free_before - 2
-    # The prepend=True path that used to crash the buddy allocator.
     pool.free_blocks(chunks, prepend=True)
     assert pool.get_num_free_blocks() == free_before
     assert chunks[0].ref_cnt == 0

--- a/tests/v1/core/test_buddy_config.py
+++ b/tests/v1/core/test_buddy_config.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Single config path for the buddy/decoupled allocator (AC-6).
+
+The decoupled mode and its parameters are registered in ``vllm.envs`` and read
+through that single registry; no module performs ad-hoc ``os.environ`` parsing
+for these flags.
+"""
+
+import pytest
+
+import vllm.envs as envs
+from vllm.v1.core.block_pool import BlockPool
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_envs_expose_buddy_flags(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    assert envs.VLLM_USE_BUDDY_BLOCK_POOL is True
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "0")
+    assert envs.VLLM_USE_BUDDY_BLOCK_POOL is False
+
+
+def test_blockpool_selects_allocator_from_config(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    # The max allocation span comes from the layout and is passed in by the
+    # coordinator; there is no env knob for it. The pool forwards it to the
+    # allocator, which sizes itself (span 4 -> buddy order 2).
+    pool = BlockPool(
+        num_gpu_blocks=8, enable_caching=False, hash_block_size=1, max_allocation_span=4
+    )
+    assert pool._buddy_mode is True
+    assert pool.free_block_queue.max_order == 2
+
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "0")
+    pool_off = BlockPool(num_gpu_blocks=8, enable_caching=False, hash_block_size=1)
+    assert pool_off._buddy_mode is False

--- a/tests/v1/core/test_buddy_free_queue.py
+++ b/tests/v1/core/test_buddy_free_queue.py
@@ -1,401 +1,265 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for BuddyFreeKVCacheBlockQueue, the live buddy-backed free queue."""
+"""Tests for BuddyAllocator, the variable-span buddy allocator.
+
+Reclaim model: the allocator's free structure only holds truly-free memory.
+Cached-but-reusable blocks live in an owned EvictionPolicy; ``allocate``
+reclaims LRU candidates (dropping their hashes via ``on_evict``) when short,
+``free`` routes a cached block to the policy and an uncached one to the pool
+(coalescing), and ``reuse`` pulls a candidate back out on a prefix-cache hit.
+"""
+
+import contextlib
 
 import pytest
 
+from vllm.v1.core.buddy_free_queue import BuddyAllocator
+from vllm.v1.core.eviction_policy import LRUEvictionPolicy
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
 
-def test_adapter_order_0_only() -> None:
-    """The BlockPool-facing adapter degenerates to slab when max_order=0."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+pytestmark = pytest.mark.cpu_test
 
-    n = 8
+
+def _evict_resetting(evicted: list):
+    """on_evict that records the block and resets its hash, mirroring
+    BlockPool._maybe_evict_cached_block."""
+
+    def _on_evict(block):
+        evicted.append(block.block_id)
+        block.reset_hash()
+        return True
+
+    return _on_evict
+
+
+def _make(n=16, max_order=3, evicted=None):
+    evictor = LRUEvictionPolicy(
+        on_evict=_evict_resetting(evicted) if evicted is not None else None
+    )
     blocks = [KVCacheBlock(i) for i in range(n)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=0)
-    assert q.num_free_blocks == n
-    popped = q.popleft_n(3)
-    assert q.num_free_blocks == n - 3
-    q.append_n(popped)
-    assert q.num_free_blocks == n
+    return BuddyAllocator(blocks, max_order=max_order, evictor=evictor), evictor
 
 
-def test_adapter_multi_order_chunks() -> None:
-    """alloc_chunk / free_chunk roundtrip at higher orders."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+def _cache(block):
+    """Mark a block as carrying a prefix-cache hash."""
+    block.block_hash = ("FAKE", block.block_id)
+    return block
 
-    n = 16
-    blocks = [KVCacheBlock(i) for i in range(n)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+
+def _drain(q):
+    """Allocate every base block as span-1 chunks; return them."""
+    held = []
+    while True:
+        try:
+            held.append(q.allocate(1))
+        except ValueError:
+            break
+    return held
+
+
+def test_order_0_only_slab():
+    q, _ = _make(8, max_order=0)
+    assert q.num_free_blocks == 8
+    got = [q.allocate(1) for _ in range(3)]
+    assert q.num_free_blocks == 5
+    for b in got:
+        q.free(b)
+    assert q.num_free_blocks == 8
+
+
+def test_multi_order_alloc_free_roundtrip():
+    q, _ = _make(16, max_order=4)
     assert q.max_order == 4
-
-    b1 = q.alloc_chunk(order=2)  # 4 base blocks
-    b2 = q.alloc_chunk(order=0)  # 1 base block
-    b3 = q.alloc_chunk(order=3)  # 8 base blocks
-    assert q.num_free_blocks == n - (4 + 1 + 8)
-    # All starts must be order-aligned and base_span recorded on head.
+    b1 = q.allocate(4)
+    b2 = q.allocate(1)
+    b3 = q.allocate(8)
+    assert q.num_free_blocks == 16 - (4 + 1 + 8)
     assert b1.block_id % 4 == 0 and b1.base_span == 4
     assert b2.base_span == 1
     assert b3.block_id % 8 == 0 and b3.base_span == 8
-
-    q.append(b2)
-    q.append(b1)
-    q.append(b3)
-    assert q.num_free_blocks == n
-
-
-def test_adapter_mixed_order_and_order_0() -> None:
-    """popleft (legacy order-0 path) coexists with alloc_chunk."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    n = 16
-    blocks = [KVCacheBlock(i) for i in range(n)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
-    # Allocate a few singles, a large chunk, more singles. Free in mixed order.
-    singles = q.popleft_n(3)
-    large = q.alloc_chunk(order=3)  # 8 blocks
-    more_singles = q.popleft_n(2)
-    assert q.num_free_blocks == n - 3 - 8 - 2
-
-    q.append_n(singles)
-    q.append(large)
-    q.append_n(more_singles)
-    assert q.num_free_blocks == n
-
-
-def test_adapter_oom_falls_back_via_value_error() -> None:
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    n = 8
-    blocks = [KVCacheBlock(i) for i in range(n)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=3)
-    q.alloc_chunk(order=3)  # uses the whole pool
-    with pytest.raises(ValueError):
-        q.alloc_chunk(order=0)
-
-
-def test_base_span_set_on_alloc() -> None:
-    """alloc_chunk records base_span on the returned head block."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
-    for order in (0, 1, 2, 3):
-        h = q.alloc_chunk(order=order)
-        assert h.base_span == (1 << order)
-        assert h.block_id % (1 << order) == 0
-        q.append(h)
-
-
-def test_remove_uses_block_base_span() -> None:
-    """remove(block) reads block.base_span — no order parameter."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
-
-    # Allocate then free a chunk so it sits in its order's LRU.
-    head = q.alloc_chunk(order=2)
-    q.append(head)
-    # After the free, head is back in a free list at some span >= 4
-    # (eager coalesce may have promoted it). Read the span off the block.
-    assert head.base_span >= 4
-    free_before = q.num_free_blocks
-    q.remove(head)
-    assert q.num_free_blocks == free_before - head.base_span
-    # Re-appending should restore the count.
-    q.append(head)
-    assert q.num_free_blocks == free_before
-
-
-def test_remove_of_mid_lru_is_o1() -> None:
-    """remove unlinks a block in the middle of an order's LRU correctly."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    # max_order=0 so each freed block lives independently in order-0 LRU.
-    blocks = [KVCacheBlock(i) for i in range(8)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=0)
-    # Pop several singles, then free in a known order to seed the LRU.
-    a, b, c, d = q.popleft_n(4)
-    for blk in (a, b, c, d):
-        q.append(blk)
-    # Free list head→tail order is now: remaining initial blocks, then a,b,c,d
-    # in append order. Remove the middle (c).
-    free_before = q.num_free_blocks
-    q.remove(c)
-    assert q.num_free_blocks == free_before - 1
-    # c is no longer in any list.
-    assert c.prev_free_block is None and c.next_free_block is None
-    # The list is still well-formed (no dangling).
-    visible = q.get_all_free_blocks()
-    assert c not in visible
-    # popping all remaining yields exactly free_before - 1 blocks.
-    assert len(q.popleft_n(q.num_free_blocks)) == free_before - 1
-
-
-def test_popleft_auto_splits_from_higher_order() -> None:
-    """popleft with no order-0 chunks must split the next-larger LRU head."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    # max_order=2 means the pool is seeded with 4 order-2 chunks (16/4).
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2)
-    # Initially order-0 LRU is empty. popleft must split an order-2 chunk
-    # into two order-1 buddies, then one of those into two order-0 buddies.
-    b = q.popleft()
-    assert b.base_span == 1
-    # Sibling at order 0 and buddy at order 1 should now be in their LRUs.
-    free_per_order = [0, 0, 0]
-    for blk in q.get_all_free_blocks():
-        free_per_order[blk.base_span.bit_length() - 1] += 1
-    assert free_per_order[0] >= 1, "split should leave a sibling at order 0"
-    assert free_per_order[1] >= 1, "split should leave a buddy at order 1"
-
-
-def test_append_coalesces_with_free_buddy() -> None:
-    """append eagerly merges with a free buddy at the same order."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
-    # Alloc two order-0 buddies; freeing both should coalesce all the way
-    # back to a single order-4 chunk.
-    head4 = q.alloc_chunk(order=4)
-    assert q.num_free_blocks == 0
-    q.append(head4)
-    free = q.get_all_free_blocks()
-    assert len(free) == 1 and free[0].base_span == 16
-
-
-def test_on_evict_fires_when_splitting_cached_chunk() -> None:
-    """alloc that walks up and splits a cached parent invokes on_evict."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    evicted: list[KVCacheBlock] = []
-    q = BuddyFreeKVCacheBlockQueue(
-        blocks, max_order=4, on_evict=lambda b: (evicted.append(b), True)[1]
-    )
-    # Drain the pool so head's buddy is allocated (still held by caller) and
-    # no coalesce will happen on append. After this, order-2 LRU is empty.
-    head = q.alloc_chunk(order=2)  # blocks[0..3]
-    _other = q.alloc_chunk(order=2)  # blocks[4..7] — head's buddy
-    _hi = q.alloc_chunk(order=3)  # blocks[8..15]
-    # Pretend the BlockPool registered a hash for head.
-    head._block_hash = "FAKE_HASH_FOR_HEAD"  # noqa: SLF001
-    q.append(head)
-    # head sits alone in order-2 LRU (its buddy is still allocated, so
-    # coalescing has nothing to do). Hash preserved.
-    assert head.block_hash is not None
-    assert head in q.get_all_free_blocks()
-    evicted.clear()
-
-    # Now ask for order 0. The only free chunk is head at order 2; the
-    # queue walks up, pops head, evicts its hash, then splits down.
-    leaf = q.alloc_chunk(order=0)
-    assert leaf.base_span == 1
-    assert evicted == [head], f"expected on_evict to fire once for head, got {evicted}"
-
-
-def test_coalesce_skipped_when_cached_hash_present() -> None:
-    """append that would coalesce two cached siblings instead keeps both
-    individually cached. Coalescing resumes once a sibling is uncached."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    evicted: list[KVCacheBlock] = []
-    q = BuddyFreeKVCacheBlockQueue(
-        blocks, max_order=4, on_evict=lambda b: (evicted.append(b), True)[1]
-    )
-    # Two order-2 buddies: chunks at start ids 0 and 4 (0 ^ 4 = 4 → buddies).
-    a = q.alloc_chunk(order=2)
-    b = q.alloc_chunk(order=2)
-    assert {a.block_id, b.block_id} == {0, 4}
-    a._block_hash = "HASH_A"  # noqa: SLF001
-    b._block_hash = "HASH_B"  # noqa: SLF001
-    # Free a — sits in order-2 LRU with its hash; b still allocated.
-    q.append(a)
-    assert evicted == [], "no coalesce → no eviction"
-    assert a.block_hash == "HASH_A"
-    # Free b — would normally coalesce with a, but both are cached. Skip
-    # coalescing; both remain in order-2 LRU with hashes intact.
-    q.append(b)
-    assert evicted == [], f"expected no eviction (cache preserved), got {evicted}"
-    assert a.block_hash == "HASH_A" and b.block_hash == "HASH_B"
-    free = q.get_all_free_blocks()
-    # a and b remain individually in the free pool at order 2 (no coalesce).
-    cached_free = [blk for blk in free if blk.block_id in {a.block_id, b.block_id}]
-    assert {blk.block_id for blk in cached_free} == {a.block_id, b.block_id}
-    assert all(blk.base_span == 4 for blk in cached_free)
-
-    # Once a's hash is dropped (e.g. BlockPool evicted via LRU), the next
-    # append against b should be able to coalesce them.
-    a._block_hash = None  # noqa: SLF001
-    # Simulate b being re-touched by allocator (alloc + free) — the alloc
-    # path is what would trigger coalescing in a real workload. Simplest
-    # exercise: remove b and re-append; with a now uncached, append(b)
-    # coalesces them into an order-3 chunk.
-    q.remove(b)
-    b._block_hash = None  # noqa: SLF001
-    q.append(b)
-    free = q.get_all_free_blocks()
-    # After hashes are cleared, coalescing cascades all the way up: a+b → 3,
-    # and that buddies with the leftover order-3 chunk [8..15] → 4.
-    assert len(free) == 1 and free[0].base_span == 16, (
-        f"expected full coalesce after hashes cleared, got {free}"
-    )
-
-
-def test_on_evict_skipped_when_block_has_no_hash() -> None:
-    """on_evict is not called when the affected chunk has no hash."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    calls = 0
-
-    def on_evict(_b):
-        nonlocal calls
-        calls += 1
-        return True
-
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4, on_evict=on_evict)
-    # Pure alloc/free of an order-2 chunk that was never cached.
-    h = q.alloc_chunk(order=2)
-    q.append(h)
-    assert calls == 0, "alloc+free without caching shouldn't evict anything"
-    # Force a split of an uncached chunk — also no eviction.
-    _ = q.alloc_chunk(order=0)
-    assert calls == 0
-
-
-def test_remove_then_reappend_preserves_base_span() -> None:
-    """Round-trip: remove → caller holds chunk → append returns it intact."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
-    head = q.alloc_chunk(order=2)
-    q.append(head)  # back in some order's LRU
-    saved_span = head.base_span
-    q.remove(head)
-    # base_span remains set on the block while caller holds it.
-    assert head.base_span == saved_span
-    q.append(head)
-    # And the queue still accounts for it correctly.
+    q.free(b2)
+    q.free(b1)
+    q.free(b3)
     assert q.num_free_blocks == 16
 
 
-def test_alloc_prefers_splitting_uncached_over_evicting_cached() -> None:
-    """alloc_chunk should split a higher-order uncached chunk rather than
-    evict a same-order cached chunk when the requested order is non-empty
-    but its head is cached."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    evicted: list[KVCacheBlock] = []
-    q = BuddyFreeKVCacheBlockQueue(
-        blocks, max_order=4, on_evict=lambda b: (evicted.append(b), True)[1]
-    )
-    # Carve out two cached order-2 chunks (siblings won't coalesce).
-    a = q.alloc_chunk(order=2)
-    b = q.alloc_chunk(order=2)
-    a._block_hash = "HASH_A"  # noqa: SLF001
-    b._block_hash = "HASH_B"  # noqa: SLF001
-    q.append(a)
-    q.append(b)
-    # order-2 LRU now has two cached chunks. order-4 LRU still has fresh
-    # max-order chunk(s) — the rest of the pool was untouched.
-    assert evicted == []
-    assert a.block_hash == "HASH_A" and b.block_hash == "HASH_B"
-
-    # Ask for order 2. Old policy would pop a's LRU head (cached) and evict.
-    # New policy: prefer splitting an uncached higher-order chunk.
-    new_chunk = q.alloc_chunk(order=2)
-    assert evicted == [], (
-        f"expected no eviction (uncached higher-order available), got {evicted}"
-    )
-    assert a.block_hash == "HASH_A" and b.block_hash == "HASH_B"
-    assert new_chunk.base_span == 4
-    # And the chunk we got should be fresh — not a or b.
-    assert new_chunk.block_id not in {a.block_id, b.block_id}
+def test_base_span_and_alignment():
+    q, _ = _make(16, max_order=4)
+    for span in (1, 2, 4, 8):
+        h = q.allocate(span)
+        assert h.base_span == span
+        assert h.block_id % span == 0
+        q.free(h)
 
 
-def test_alloc_falls_back_to_evict_when_no_uncached() -> None:
-    """When every order >= requested has only cached chunks, alloc evicts
-    the LRU-head cached chunk at the requested order."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(8)]
-    evicted: list[KVCacheBlock] = []
-    q = BuddyFreeKVCacheBlockQueue(
-        blocks, max_order=3, on_evict=lambda b: (evicted.append(b), True)[1]
-    )
-    # Allocate the whole pool as two cached order-2 chunks.
-    a = q.alloc_chunk(order=2)
-    b = q.alloc_chunk(order=2)
-    a._block_hash = "HASH_A"  # noqa: SLF001
-    b._block_hash = "HASH_B"  # noqa: SLF001
-    q.append(a)
-    q.append(b)
-    # All free chunks are cached. Asking for order 2 must evict.
-    assert evicted == []
-    q.alloc_chunk(order=2)
-    assert len(evicted) == 1, f"expected exactly one eviction, got {evicted}"
-    # The evicted block is the LRU-head of order 2 (a, freed first).
-    assert evicted[0].block_id == a.block_id
-    # b retains its hash.
-    assert b.block_hash == "HASH_B"
+def test_null_block_id_zero_preserved_across_cycles():
+    q, _ = _make(8, max_order=3)
+    for _ in range(3):
+        first = q.allocate(1)
+        assert first.block_id == 0, "NULL_BLOCK_ID=0 invariant broken"
+        q.free(first)  # coalesces back for the next cycle
 
 
-def test_initial_pool_null_block_id_zero() -> None:
-    """First popleft after init must return block_id 0 (NULL_BLOCK_ID
-    invariant). Uncached-at-head seeding reverses insert order to preserve
-    this."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(32)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=3)
-    first = q.popleft()
-    assert first.block_id == 0, (
-        f"NULL_BLOCK_ID = 0 invariant broken: popleft returned {first.block_id}"
-    )
-
-
-def test_allocated_chunks_dont_overlap() -> None:
-    """Allocated chunks cover disjoint, aligned base-block ranges."""
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
-
-    blocks = [KVCacheBlock(i) for i in range(16)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+def test_allocated_chunks_dont_overlap():
+    q, _ = _make(16, max_order=4)
     allocs: list[tuple[int, int]] = []
-    for order in [0, 0, 1, 2, 0, 3]:
+    for span in [1, 1, 2, 4, 1, 8]:
         try:
-            blk = q.alloc_chunk(order=order)
+            blk = q.allocate(span)
         except ValueError:
             break
-        # Each chunk start is aligned to its size.
-        assert blk.block_id % (1 << order) == 0
-        allocs.append((blk.block_id, 1 << order))
-    # Verify no two allocated chunks overlap.
+        assert blk.block_id % span == 0
+        allocs.append((blk.block_id, span))
     intervals = sorted(allocs)
     for i in range(len(intervals) - 1):
         end_i = intervals[i][0] + intervals[i][1]
         assert end_i <= intervals[i + 1][0], (
             f"overlap between {intervals[i]} and {intervals[i + 1]}"
         )
+
+
+def test_free_coalesces_uncached_buddies():
+    q, _ = _make(16, max_order=4)
+    head = q.allocate(16)
+    assert q.num_free_blocks == 0
+    q.free(head)  # uncached -> pool, coalesces fully
+    free = q.get_all_free_blocks()
+    assert len(free) == 1 and free[0].base_span == 16
+
+
+def test_buddy_xor_coalesce_merges_to_min_id():
+    q, _ = _make(8, max_order=3)
+    a = q.allocate(4)
+    b = q.allocate(4)
+    assert a.block_id == 0 and b.block_id == 4  # buddies at order 2
+    q.free(a)
+    q.free(b)
+    frees = q.get_all_free_blocks()
+    assert len(frees) == 1
+    assert frees[0].block_id == 0 and frees[0].base_span == 8
+    assert q.num_free_blocks == 8
+
+
+def test_free_routes_cached_to_evictor_uncached_to_pool():
+    q, evictor = _make(8, max_order=2, evicted=[])
+    a = q.allocate(1)
+    b = q.allocate(1)
+    _cache(a)
+    q.free(a)  # cached -> evictor candidate
+    q.free(b)  # uncached -> pool
+    assert evictor.num_reclaimable == 1
+    assert a in evictor.reclaimable_chunks()
+    # num_free_blocks counts pool free + reclaimable candidates.
+    assert q.num_free_blocks == 8
+
+
+def test_reclaim_prefers_pool_then_evicts_lru_candidate():
+    evicted: list[int] = []
+    q, evictor = _make(8, max_order=2, evicted=evicted)
+    held = _drain(q)
+    assert len(held) == 8 and q.num_free_blocks == 0
+    # Free four as cached candidates, four back to the pool.
+    for b in held[:4]:
+        _cache(b)
+        q.free(b)
+    for b in held[4:]:
+        q.free(b)
+    assert evictor.num_reclaimable == 4
+    assert q.num_free_blocks == 8
+    # The four pool blocks satisfy allocations with no eviction.
+    [q.allocate(1) for _ in range(4)]
+    assert evicted == []
+    # The next allocation must reclaim an LRU candidate.
+    nxt = q.allocate(1)
+    assert len(evicted) == 1
+    assert nxt.block_hash is None, "reclaimed memory handed out clean"
+
+
+def test_reuse_pulls_candidate_back_out():
+    q, evictor = _make(8, max_order=2, evicted=[])
+    b = q.allocate(1)
+    _cache(b)
+    q.free(b)
+    assert evictor.num_reclaimable == 1
+    q.reuse(b)  # prefix-cache hit
+    assert evictor.num_reclaimable == 0
+    assert b.prev_free_block is None and b.next_free_block is None
+
+
+def test_oom_raises_when_no_free_and_no_candidates():
+    q, _ = _make(8, max_order=3, evicted=[])
+    q.allocate(8)  # whole pool, uncached -> caller holds it
+    with pytest.raises(ValueError):
+        q.allocate(1)
+
+
+def test_can_allocate_majorization_and_fragmentation():
+    q, _ = _make(8, max_order=2, evicted=[])
+    # Fresh: two order-2 chunks = 8 base blocks.
+    assert q.can_allocate({4: 2})
+    assert not q.can_allocate({4: 3})
+    assert q.can_allocate({4: 1, 1: 4})
+    assert not q.can_allocate({4: 1, 1: 5})
+    assert q.can_allocate({2: 1, 1: 6})
+    assert q.can_allocate({})
+
+    # Fragment: hold odd ids, free even ids -> four scattered order-0 blocks.
+    held = _drain(q)
+    for b in held:
+        if b.block_id % 2 == 0:
+            q.free(b)
+    assert q.num_free_blocks == 4
+    assert q.can_allocate({1: 4})
+    assert not q.can_allocate({1: 5})
+    # Four free base blocks but no order-1 chunk can be carved.
+    assert not q.can_allocate({2: 1})
+
+
+def test_can_allocate_counts_reclaimable_candidates():
+    # Pool seeded as two order-1 chunks (n=4, max_order=1).
+    q, evictor = _make(4, max_order=1, evicted=[])
+    held = [q.allocate(2), q.allocate(2)]
+    assert q.num_free_blocks == 0
+    _cache(held[0])
+    q.free(held[0])  # span-2 cached candidate -> evictor
+    q.free(held[1])  # span-2 uncached -> pool
+    assert evictor.num_reclaimable == 2
+    # Pool alone has one span-2 chunk; the reclaimable candidate provides the
+    # second, so a two-chunk span-2 demand is feasible (and three is not).
+    assert q.can_allocate({2: 2})
+    assert not q.can_allocate({2: 3})
+
+
+def test_tail_blocks_isolated_and_drain_last():
+    # n=12, max_order=3 -> aligned prefix one order-3 chunk (0..7); 8..11 tail.
+    q, _ = _make(12, max_order=3)
+    aligned = [q.allocate(1).block_id for _ in range(8)]
+    assert all(i < 8 for i in aligned), aligned
+    tail = [q.allocate(1).block_id for _ in range(4)]
+    assert sorted(tail) == [8, 9, 10, 11]
+
+
+def test_order0_falls_back_to_tail_when_aligned_exhausted():
+    q, _ = _make(12, max_order=3)
+    big = q.allocate(8)  # consumes the whole aligned region
+    assert big.block_id == 0
+    b = q.allocate(1)  # must come from the tail
+    assert b.block_id in (8, 9, 10, 11)
+
+
+def test_num_free_blocks_matches_chunk_sum_through_ops():
+    q, _ = _make(16, max_order=3)
+
+    def pool_base(alloc):
+        return sum(b.base_span for b in alloc.get_all_free_blocks())
+
+    assert q.num_free_blocks == pool_base(q) == 16
+    held = []
+    for span in [1, 4, 2, 1, 8]:
+        with contextlib.suppress(ValueError):
+            held.append(q.allocate(span))
+        assert q.num_free_blocks == pool_base(q)
+    for b in held:
+        q.free(b)
+        assert q.num_free_blocks == pool_base(q)
+    assert q.num_free_blocks == 16

--- a/tests/v1/core/test_buddy_free_queue.py
+++ b/tests/v1/core/test_buddy_free_queue.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for BuddyFreeKVCacheBlockQueue, the live buddy-backed free queue."""
+
+import pytest
+
+
+def test_adapter_order_0_only() -> None:
+    """The BlockPool-facing adapter degenerates to slab when max_order=0."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    n = 8
+    blocks = [KVCacheBlock(i) for i in range(n)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=0)
+    assert q.num_free_blocks == n
+    popped = q.popleft_n(3)
+    assert q.num_free_blocks == n - 3
+    q.append_n(popped)
+    assert q.num_free_blocks == n
+
+
+def test_adapter_multi_order_chunks() -> None:
+    """alloc_chunk / free_chunk roundtrip at higher orders."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    n = 16
+    blocks = [KVCacheBlock(i) for i in range(n)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+    assert q.max_order == 4
+
+    b1 = q.alloc_chunk(order=2)  # 4 base blocks
+    b2 = q.alloc_chunk(order=0)  # 1 base block
+    b3 = q.alloc_chunk(order=3)  # 8 base blocks
+    assert q.num_free_blocks == n - (4 + 1 + 8)
+    # All starts must be order-aligned and base_span recorded on head.
+    assert b1.block_id % 4 == 0 and b1.base_span == 4
+    assert b2.base_span == 1
+    assert b3.block_id % 8 == 0 and b3.base_span == 8
+
+    q.append(b2)
+    q.append(b1)
+    q.append(b3)
+    assert q.num_free_blocks == n
+
+
+def test_adapter_mixed_order_and_order_0() -> None:
+    """popleft (legacy order-0 path) coexists with alloc_chunk."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    n = 16
+    blocks = [KVCacheBlock(i) for i in range(n)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+    # Allocate a few singles, a large chunk, more singles. Free in mixed order.
+    singles = q.popleft_n(3)
+    large = q.alloc_chunk(order=3)  # 8 blocks
+    more_singles = q.popleft_n(2)
+    assert q.num_free_blocks == n - 3 - 8 - 2
+
+    q.append_n(singles)
+    q.append(large)
+    q.append_n(more_singles)
+    assert q.num_free_blocks == n
+
+
+def test_adapter_oom_falls_back_via_value_error() -> None:
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    n = 8
+    blocks = [KVCacheBlock(i) for i in range(n)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=3)
+    q.alloc_chunk(order=3)  # uses the whole pool
+    with pytest.raises(ValueError):
+        q.alloc_chunk(order=0)
+
+
+def test_base_span_set_on_alloc() -> None:
+    """alloc_chunk records base_span on the returned head block."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+    for order in (0, 1, 2, 3):
+        h = q.alloc_chunk(order=order)
+        assert h.base_span == (1 << order)
+        assert h.block_id % (1 << order) == 0
+        q.append(h)
+
+
+def test_remove_uses_block_base_span() -> None:
+    """remove(block) reads block.base_span — no order parameter."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+
+    # Allocate then free a chunk so it sits in its order's LRU.
+    head = q.alloc_chunk(order=2)
+    q.append(head)
+    # After the free, head is back in a free list at some span >= 4
+    # (eager coalesce may have promoted it). Read the span off the block.
+    assert head.base_span >= 4
+    free_before = q.num_free_blocks
+    q.remove(head)
+    assert q.num_free_blocks == free_before - head.base_span
+    # Re-appending should restore the count.
+    q.append(head)
+    assert q.num_free_blocks == free_before
+
+
+def test_remove_of_mid_lru_is_o1() -> None:
+    """remove unlinks a block in the middle of an order's LRU correctly."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    # max_order=0 so each freed block lives independently in order-0 LRU.
+    blocks = [KVCacheBlock(i) for i in range(8)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=0)
+    # Pop several singles, then free in a known order to seed the LRU.
+    a, b, c, d = q.popleft_n(4)
+    for blk in (a, b, c, d):
+        q.append(blk)
+    # Free list head→tail order is now: remaining initial blocks, then a,b,c,d
+    # in append order. Remove the middle (c).
+    free_before = q.num_free_blocks
+    q.remove(c)
+    assert q.num_free_blocks == free_before - 1
+    # c is no longer in any list.
+    assert c.prev_free_block is None and c.next_free_block is None
+    # The list is still well-formed (no dangling).
+    visible = q.get_all_free_blocks()
+    assert c not in visible
+    # popping all remaining yields exactly free_before - 1 blocks.
+    assert len(q.popleft_n(q.num_free_blocks)) == free_before - 1
+
+
+def test_popleft_auto_splits_from_higher_order() -> None:
+    """popleft with no order-0 chunks must split the next-larger LRU head."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    # max_order=2 means the pool is seeded with 4 order-2 chunks (16/4).
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=2)
+    # Initially order-0 LRU is empty. popleft must split an order-2 chunk
+    # into two order-1 buddies, then one of those into two order-0 buddies.
+    b = q.popleft()
+    assert b.base_span == 1
+    # Sibling at order 0 and buddy at order 1 should now be in their LRUs.
+    free_per_order = [0, 0, 0]
+    for blk in q.get_all_free_blocks():
+        free_per_order[blk.base_span.bit_length() - 1] += 1
+    assert free_per_order[0] >= 1, "split should leave a sibling at order 0"
+    assert free_per_order[1] >= 1, "split should leave a buddy at order 1"
+
+
+def test_append_coalesces_with_free_buddy() -> None:
+    """append eagerly merges with a free buddy at the same order."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+    # Alloc two order-0 buddies; freeing both should coalesce all the way
+    # back to a single order-4 chunk.
+    head4 = q.alloc_chunk(order=4)
+    assert q.num_free_blocks == 0
+    q.append(head4)
+    free = q.get_all_free_blocks()
+    assert len(free) == 1 and free[0].base_span == 16
+
+
+def test_on_evict_fires_when_splitting_cached_chunk() -> None:
+    """alloc that walks up and splits a cached parent invokes on_evict."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    evicted: list[KVCacheBlock] = []
+    q = BuddyFreeKVCacheBlockQueue(
+        blocks, max_order=4, on_evict=lambda b: (evicted.append(b), True)[1]
+    )
+    # Drain the pool so head's buddy is allocated (still held by caller) and
+    # no coalesce will happen on append. After this, order-2 LRU is empty.
+    head = q.alloc_chunk(order=2)  # blocks[0..3]
+    _other = q.alloc_chunk(order=2)  # blocks[4..7] — head's buddy
+    _hi = q.alloc_chunk(order=3)  # blocks[8..15]
+    # Pretend the BlockPool registered a hash for head.
+    head._block_hash = "FAKE_HASH_FOR_HEAD"  # noqa: SLF001
+    q.append(head)
+    # head sits alone in order-2 LRU (its buddy is still allocated, so
+    # coalescing has nothing to do). Hash preserved.
+    assert head.block_hash is not None
+    assert head in q.get_all_free_blocks()
+    evicted.clear()
+
+    # Now ask for order 0. The only free chunk is head at order 2; the
+    # queue walks up, pops head, evicts its hash, then splits down.
+    leaf = q.alloc_chunk(order=0)
+    assert leaf.base_span == 1
+    assert evicted == [head], f"expected on_evict to fire once for head, got {evicted}"
+
+
+def test_coalesce_skipped_when_cached_hash_present() -> None:
+    """append that would coalesce two cached siblings instead keeps both
+    individually cached. Coalescing resumes once a sibling is uncached."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    evicted: list[KVCacheBlock] = []
+    q = BuddyFreeKVCacheBlockQueue(
+        blocks, max_order=4, on_evict=lambda b: (evicted.append(b), True)[1]
+    )
+    # Two order-2 buddies: chunks at start ids 0 and 4 (0 ^ 4 = 4 → buddies).
+    a = q.alloc_chunk(order=2)
+    b = q.alloc_chunk(order=2)
+    assert {a.block_id, b.block_id} == {0, 4}
+    a._block_hash = "HASH_A"  # noqa: SLF001
+    b._block_hash = "HASH_B"  # noqa: SLF001
+    # Free a — sits in order-2 LRU with its hash; b still allocated.
+    q.append(a)
+    assert evicted == [], "no coalesce → no eviction"
+    assert a.block_hash == "HASH_A"
+    # Free b — would normally coalesce with a, but both are cached. Skip
+    # coalescing; both remain in order-2 LRU with hashes intact.
+    q.append(b)
+    assert evicted == [], f"expected no eviction (cache preserved), got {evicted}"
+    assert a.block_hash == "HASH_A" and b.block_hash == "HASH_B"
+    free = q.get_all_free_blocks()
+    # a and b remain individually in the free pool at order 2 (no coalesce).
+    cached_free = [blk for blk in free if blk.block_id in {a.block_id, b.block_id}]
+    assert {blk.block_id for blk in cached_free} == {a.block_id, b.block_id}
+    assert all(blk.base_span == 4 for blk in cached_free)
+
+    # Once a's hash is dropped (e.g. BlockPool evicted via LRU), the next
+    # append against b should be able to coalesce them.
+    a._block_hash = None  # noqa: SLF001
+    # Simulate b being re-touched by allocator (alloc + free) — the alloc
+    # path is what would trigger coalescing in a real workload. Simplest
+    # exercise: remove b and re-append; with a now uncached, append(b)
+    # coalesces them into an order-3 chunk.
+    q.remove(b)
+    b._block_hash = None  # noqa: SLF001
+    q.append(b)
+    free = q.get_all_free_blocks()
+    # After hashes are cleared, coalescing cascades all the way up: a+b → 3,
+    # and that buddies with the leftover order-3 chunk [8..15] → 4.
+    assert len(free) == 1 and free[0].base_span == 16, (
+        f"expected full coalesce after hashes cleared, got {free}"
+    )
+
+
+def test_on_evict_skipped_when_block_has_no_hash() -> None:
+    """on_evict is not called when the affected chunk has no hash."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    calls = 0
+
+    def on_evict(_b):
+        nonlocal calls
+        calls += 1
+        return True
+
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4, on_evict=on_evict)
+    # Pure alloc/free of an order-2 chunk that was never cached.
+    h = q.alloc_chunk(order=2)
+    q.append(h)
+    assert calls == 0, "alloc+free without caching shouldn't evict anything"
+    # Force a split of an uncached chunk — also no eviction.
+    _ = q.alloc_chunk(order=0)
+    assert calls == 0
+
+
+def test_remove_then_reappend_preserves_base_span() -> None:
+    """Round-trip: remove → caller holds chunk → append returns it intact."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+    head = q.alloc_chunk(order=2)
+    q.append(head)  # back in some order's LRU
+    saved_span = head.base_span
+    q.remove(head)
+    # base_span remains set on the block while caller holds it.
+    assert head.base_span == saved_span
+    q.append(head)
+    # And the queue still accounts for it correctly.
+    assert q.num_free_blocks == 16
+
+
+def test_alloc_prefers_splitting_uncached_over_evicting_cached() -> None:
+    """alloc_chunk should split a higher-order uncached chunk rather than
+    evict a same-order cached chunk when the requested order is non-empty
+    but its head is cached."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    evicted: list[KVCacheBlock] = []
+    q = BuddyFreeKVCacheBlockQueue(
+        blocks, max_order=4, on_evict=lambda b: (evicted.append(b), True)[1]
+    )
+    # Carve out two cached order-2 chunks (siblings won't coalesce).
+    a = q.alloc_chunk(order=2)
+    b = q.alloc_chunk(order=2)
+    a._block_hash = "HASH_A"  # noqa: SLF001
+    b._block_hash = "HASH_B"  # noqa: SLF001
+    q.append(a)
+    q.append(b)
+    # order-2 LRU now has two cached chunks. order-4 LRU still has fresh
+    # max-order chunk(s) — the rest of the pool was untouched.
+    assert evicted == []
+    assert a.block_hash == "HASH_A" and b.block_hash == "HASH_B"
+
+    # Ask for order 2. Old policy would pop a's LRU head (cached) and evict.
+    # New policy: prefer splitting an uncached higher-order chunk.
+    new_chunk = q.alloc_chunk(order=2)
+    assert evicted == [], (
+        f"expected no eviction (uncached higher-order available), got {evicted}"
+    )
+    assert a.block_hash == "HASH_A" and b.block_hash == "HASH_B"
+    assert new_chunk.base_span == 4
+    # And the chunk we got should be fresh — not a or b.
+    assert new_chunk.block_id not in {a.block_id, b.block_id}
+
+
+def test_alloc_falls_back_to_evict_when_no_uncached() -> None:
+    """When every order >= requested has only cached chunks, alloc evicts
+    the LRU-head cached chunk at the requested order."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(8)]
+    evicted: list[KVCacheBlock] = []
+    q = BuddyFreeKVCacheBlockQueue(
+        blocks, max_order=3, on_evict=lambda b: (evicted.append(b), True)[1]
+    )
+    # Allocate the whole pool as two cached order-2 chunks.
+    a = q.alloc_chunk(order=2)
+    b = q.alloc_chunk(order=2)
+    a._block_hash = "HASH_A"  # noqa: SLF001
+    b._block_hash = "HASH_B"  # noqa: SLF001
+    q.append(a)
+    q.append(b)
+    # All free chunks are cached. Asking for order 2 must evict.
+    assert evicted == []
+    q.alloc_chunk(order=2)
+    assert len(evicted) == 1, f"expected exactly one eviction, got {evicted}"
+    # The evicted block is the LRU-head of order 2 (a, freed first).
+    assert evicted[0].block_id == a.block_id
+    # b retains its hash.
+    assert b.block_hash == "HASH_B"
+
+
+def test_initial_pool_null_block_id_zero() -> None:
+    """First popleft after init must return block_id 0 (NULL_BLOCK_ID
+    invariant). Uncached-at-head seeding reverses insert order to preserve
+    this."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(32)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=3)
+    first = q.popleft()
+    assert first.block_id == 0, (
+        f"NULL_BLOCK_ID = 0 invariant broken: popleft returned {first.block_id}"
+    )
+
+
+def test_allocated_chunks_dont_overlap() -> None:
+    """Allocated chunks cover disjoint, aligned base-block ranges."""
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+    allocs: list[tuple[int, int]] = []
+    for order in [0, 0, 1, 2, 0, 3]:
+        try:
+            blk = q.alloc_chunk(order=order)
+        except ValueError:
+            break
+        # Each chunk start is aligned to its size.
+        assert blk.block_id % (1 << order) == 0
+        allocs.append((blk.block_id, 1 << order))
+    # Verify no two allocated chunks overlap.
+    intervals = sorted(allocs)
+    for i in range(len(intervals) - 1):
+        end_i = intervals[i][0] + intervals[i][1]
+        assert end_i <= intervals[i + 1][0], (
+            f"overlap between {intervals[i]} and {intervals[i + 1]}"
+        )

--- a/tests/v1/core/test_buddy_invariants.py
+++ b/tests/v1/core/test_buddy_invariants.py
@@ -1,58 +1,56 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Structural invariants of BuddyFreeKVCacheBlockQueue (AC-7).
+"""Structural invariants of BuddyAllocator (AC-7).
 
-Complements test_buddy_free_queue.py (alignment, split eviction, coalesce-skip,
-the two uncached/cached alloc passes) with: free-count accounting, buddy-XOR
-coalescing, NULL_BLOCK_ID=0 preservation across alloc/coalesce cycles,
-tail-block isolation and fallback, and on_evict timing.
+Free-count accounting, buddy-XOR coalescing, NULL_BLOCK_ID=0 preservation
+across alloc/coalesce cycles, tail-block isolation/fallback, and the reclaim
+boundary (no eviction while uncached free memory remains).
 """
 
 import contextlib
 
 import pytest
 
-from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+from vllm.v1.core.buddy_free_queue import BuddyAllocator
+from vllm.v1.core.eviction_policy import LRUEvictionPolicy
 from vllm.v1.core.kv_cache_utils import KVCacheBlock
 
 pytestmark = pytest.mark.cpu_test
 
 
 def _make(n=16, max_order=3, on_evict=None):
-    return BuddyFreeKVCacheBlockQueue(
-        [KVCacheBlock(i) for i in range(n)], max_order=max_order, on_evict=on_evict
+    evictor = LRUEvictionPolicy(on_evict=on_evict)
+    return BuddyAllocator(
+        [KVCacheBlock(i) for i in range(n)], max_order=max_order, evictor=evictor
     )
 
 
-def _free_base_from_chunks(q):
-    """Total free base blocks recomputed from the free chunk heads, each of
-    size base_span (tail-fallback ids have base_span 1)."""
+def _pool_base(q):
+    """Total free base blocks recomputed from the pool chunk heads."""
     return sum(b.base_span for b in q.get_all_free_blocks())
 
 
 def test_num_free_blocks_matches_chunk_sum_through_ops():
     q = _make(16, 3)
-    assert q.num_free_blocks == _free_base_from_chunks(q) == 16
+    assert q.num_free_blocks == _pool_base(q) == 16
     held = []
-    for order in [0, 2, 1, 0, 3]:
+    for span in [1, 4, 2, 1, 8]:
         with contextlib.suppress(ValueError):
-            held.append(q.alloc_chunk(order=order))
-        # Accounting stays consistent after every allocation.
-        assert q.num_free_blocks == _free_base_from_chunks(q)
+            held.append(q.allocate(span))
+        assert q.num_free_blocks == _pool_base(q)
     for b in held:
-        q.append(b)
-        assert q.num_free_blocks == _free_base_from_chunks(q)
+        q.free(b)
+        assert q.num_free_blocks == _pool_base(q)
     assert q.num_free_blocks == 16
 
 
 def test_buddy_xor_coalesce_merges_to_min_id():
     q = _make(8, 3)  # one order-3 chunk covering ids 0..7
-    a = q.alloc_chunk(order=2)
-    b = q.alloc_chunk(order=2)
+    a = q.allocate(4)
+    b = q.allocate(4)
     assert a.block_id == 0 and b.block_id == 4  # buddies at order 2
-    # Freeing both buddies coalesces back to a single order-3 chunk at min id.
-    q.append(a)
-    q.append(b)
+    q.free(a)
+    q.free(b)
     frees = q.get_all_free_blocks()
     assert len(frees) == 1
     assert frees[0].block_id == 0
@@ -63,41 +61,44 @@ def test_buddy_xor_coalesce_merges_to_min_id():
 def test_null_block_id_zero_preserved_across_cycles():
     q = _make(8, 3)
     for _ in range(3):
-        first = q.popleft()
+        first = q.allocate(1)
         assert first.block_id == 0, "NULL_BLOCK_ID=0 invariant broken"
-        q.append(first)  # coalesces back to the full chunk for the next cycle
+        q.free(first)  # coalesces back to the full chunk for the next cycle
 
 
 def test_tail_blocks_isolated_and_drain_last():
     # n=12, max_order=3 -> aligned prefix is one order-3 chunk (0..7); 8..11 tail.
     q = _make(12, 3)
-    assert q._tail_free == [8, 9, 10, 11]
-    # Order-0 allocations drain the aligned region (ids < 8) first.
-    aligned = [q.alloc_chunk(order=0).block_id for _ in range(8)]
+    aligned = [q.allocate(1).block_id for _ in range(8)]
     assert all(i < 8 for i in aligned), aligned
-    # Only then do allocations come from the isolated tail list.
-    tail = [q.alloc_chunk(order=0).block_id for _ in range(4)]
+    tail = [q.allocate(1).block_id for _ in range(4)]
     assert sorted(tail) == [8, 9, 10, 11]
 
 
 def test_order0_falls_back_to_tail_when_aligned_exhausted():
     q = _make(12, 3)
-    big = q.alloc_chunk(order=3)  # consumes the whole aligned region
+    big = q.allocate(8)  # consumes the whole aligned region
     assert big.block_id == 0
-    b = q.alloc_chunk(order=0)  # must come from the tail
+    b = q.allocate(1)  # must come from the tail
     assert b.block_id in (8, 9, 10, 11)
 
 
-def test_on_evict_not_called_on_plain_append():
+def test_no_eviction_while_uncached_free_remains():
     evicted: list[int] = []
 
     def on_evict(block):
         evicted.append(block.block_id)
+        block.reset_hash()
         return True
 
     q = _make(8, 3, on_evict=on_evict)
-    blk = q.alloc_chunk(order=0)
-    # A plain append with no cached buddy to coalesce and no split must not
-    # trigger any eviction.
-    q.append(blk)
+    # A plain uncached alloc/free cycle must never reclaim a candidate.
+    blk = q.allocate(1)
+    q.free(blk)
+    assert evicted == []
+    # Even allocating the whole pool (uncached) triggers no eviction.
+    held = []
+    with contextlib.suppress(ValueError):
+        while True:
+            held.append(q.allocate(1))
     assert evicted == []

--- a/tests/v1/core/test_buddy_invariants.py
+++ b/tests/v1/core/test_buddy_invariants.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Structural invariants of BuddyFreeKVCacheBlockQueue (AC-7).
+
+Complements test_buddy_free_queue.py (alignment, split eviction, coalesce-skip,
+the two uncached/cached alloc passes) with: free-count accounting, buddy-XOR
+coalescing, NULL_BLOCK_ID=0 preservation across alloc/coalesce cycles,
+tail-block isolation and fallback, and on_evict timing.
+"""
+
+import contextlib
+
+import pytest
+
+from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _make(n=16, max_order=3, on_evict=None):
+    return BuddyFreeKVCacheBlockQueue(
+        [KVCacheBlock(i) for i in range(n)], max_order=max_order, on_evict=on_evict
+    )
+
+
+def _free_base_from_chunks(q):
+    """Total free base blocks recomputed from the free chunk heads, each of
+    size base_span (tail-fallback ids have base_span 1)."""
+    return sum(b.base_span for b in q.get_all_free_blocks())
+
+
+def test_num_free_blocks_matches_chunk_sum_through_ops():
+    q = _make(16, 3)
+    assert q.num_free_blocks == _free_base_from_chunks(q) == 16
+    held = []
+    for order in [0, 2, 1, 0, 3]:
+        with contextlib.suppress(ValueError):
+            held.append(q.alloc_chunk(order=order))
+        # Accounting stays consistent after every allocation.
+        assert q.num_free_blocks == _free_base_from_chunks(q)
+    for b in held:
+        q.append(b)
+        assert q.num_free_blocks == _free_base_from_chunks(q)
+    assert q.num_free_blocks == 16
+
+
+def test_buddy_xor_coalesce_merges_to_min_id():
+    q = _make(8, 3)  # one order-3 chunk covering ids 0..7
+    a = q.alloc_chunk(order=2)
+    b = q.alloc_chunk(order=2)
+    assert a.block_id == 0 and b.block_id == 4  # buddies at order 2
+    # Freeing both buddies coalesces back to a single order-3 chunk at min id.
+    q.append(a)
+    q.append(b)
+    frees = q.get_all_free_blocks()
+    assert len(frees) == 1
+    assert frees[0].block_id == 0
+    assert frees[0].base_span == 8
+    assert q.num_free_blocks == 8
+
+
+def test_null_block_id_zero_preserved_across_cycles():
+    q = _make(8, 3)
+    for _ in range(3):
+        first = q.popleft()
+        assert first.block_id == 0, "NULL_BLOCK_ID=0 invariant broken"
+        q.append(first)  # coalesces back to the full chunk for the next cycle
+
+
+def test_tail_blocks_isolated_and_drain_last():
+    # n=12, max_order=3 -> aligned prefix is one order-3 chunk (0..7); 8..11 tail.
+    q = _make(12, 3)
+    assert q._tail_free == [8, 9, 10, 11]
+    # Order-0 allocations drain the aligned region (ids < 8) first.
+    aligned = [q.alloc_chunk(order=0).block_id for _ in range(8)]
+    assert all(i < 8 for i in aligned), aligned
+    # Only then do allocations come from the isolated tail list.
+    tail = [q.alloc_chunk(order=0).block_id for _ in range(4)]
+    assert sorted(tail) == [8, 9, 10, 11]
+
+
+def test_order0_falls_back_to_tail_when_aligned_exhausted():
+    q = _make(12, 3)
+    big = q.alloc_chunk(order=3)  # consumes the whole aligned region
+    assert big.block_id == 0
+    b = q.alloc_chunk(order=0)  # must come from the tail
+    assert b.block_id in (8, 9, 10, 11)
+
+
+def test_on_evict_not_called_on_plain_append():
+    evicted: list[int] = []
+
+    def on_evict(block):
+        evicted.append(block.block_id)
+        return True
+
+    q = _make(8, 3, on_evict=on_evict)
+    blk = q.alloc_chunk(order=0)
+    # A plain append with no cached buddy to coalesce and no split must not
+    # trigger any eviction.
+    q.append(blk)
+    assert evicted == []

--- a/tests/v1/core/test_decoupled_admission.py
+++ b/tests/v1/core/test_decoupled_admission.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Admission accounting for decoupled hybrid paging.
+
+Covers two correctness properties of the decoupled (variable-span) path:
+
+* Base-weighted admission: a group whose logical block spans ``2**order`` base
+  blocks must report admission demand in base-block units, because the block
+  pool tracks free capacity in base blocks. Counting a span>1 logical block as
+  a single base block under-reserves capacity and can OOM after admission.
+* Single source of truth: the per-group span comes solely from the group's
+  spec/config (the ``base_span`` constructor argument). No environment
+  variable may influence it.
+"""
+
+import pytest
+import torch
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
+from vllm.v1.kv_cache_interface import SlidingWindowSpec
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _make_manager(base_span: int) -> SlidingWindowManager:
+    block_size = 2
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        sliding_window=4,  # placeholder, not relevant to the count
+    )
+    block_pool = BlockPool(
+        num_gpu_blocks=100, enable_caching=True, hash_block_size=block_size
+    )
+    return SlidingWindowManager(
+        spec,
+        block_pool=block_pool,
+        enable_caching=True,
+        kv_cache_group_id=0,
+        scheduler_block_size=block_size,
+        max_admission_blocks_per_request=10**9,
+        base_span=base_span,
+    )
+
+
+def _base_demand(manager, *args):
+    """Mirror the coordinator's per-group base-block demand: the logical-block
+    demand scaled by the group's allocation span (``logical * base_span``)."""
+    logical = manager.get_num_blocks_to_allocate(*args)
+    return logical, logical * manager.base_span
+
+
+def test_uniform_span_base_demand_equals_logical():
+    """span 1: base demand equals logical demand (baseline path)."""
+    manager = _make_manager(base_span=1)
+    block_size = manager.block_size
+    cached = [KVCacheBlock(i + 1) for i in range(10)]
+
+    assert manager.base_span == 1
+    logical, base = _base_demand(
+        manager, "1", 20 * block_size, cached, 0, 20 * block_size
+    )
+    assert logical == 20
+    assert base == logical
+
+
+def test_span_gt_one_scales_base_demand():
+    """span 4: base demand is the logical demand times the span, covering both
+    new blocks and evictable touched cached blocks."""
+    span = 4
+    block_size = 2
+    # New-only request: 20 logical blocks -> 80 base blocks.
+    manager_new = _make_manager(base_span=span)
+    assert manager_new.base_span == 4
+    cached_new = [KVCacheBlock(i + 1) for i in range(10)]
+    logical_new, base_new = _base_demand(
+        manager_new, "1", 20 * block_size, cached_new, 0, 20 * block_size
+    )
+    assert logical_new == 20
+    assert base_new == logical_new * span == 80
+
+    # Evictable-cached request: the evictable cached block is also counted in
+    # base units (the free-capacity check must reserve its span).
+    manager_evict = _make_manager(base_span=span)
+    block_pool = manager_evict.block_pool
+    evictable_block = block_pool.blocks[1]  # ref_cnt == 0, eviction candidate
+    logical_evict, base_evict = _base_demand(
+        manager_evict,
+        "req",
+        2 * block_size,
+        [evictable_block],
+        block_size,
+        2 * block_size,
+    )
+    assert logical_evict == 2
+    assert base_evict == logical_evict * span == 8
+
+
+def test_span_source_is_spec_not_env(monkeypatch):
+    """The span comes only from the spec/config; environment variables that
+    used to override per-group order have no effect anymore (AC-2)."""
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    monkeypatch.setenv("VLLM_BUDDY_GROUP_ORDERS", "7")
+    manager = _make_manager(base_span=4)
+    # The constructor argument wins; the env var is ignored entirely.
+    assert manager.base_span == 4
+    assert manager._base_span == 4
+
+
+def test_blockpool_uses_caller_derived_buddy_order(monkeypatch):
+    """In buddy mode the queue supports exactly the caller-derived order (from
+    the layout's spans). Otherwise a span>1 demand is rejected by
+    ``can_allocate_*`` and the spanned allocation raises."""
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    pool = BlockPool(
+        num_gpu_blocks=64,
+        enable_caching=False,
+        hash_block_size=1,
+        max_allocation_span=4,  # a span-4 group; buddy sizes to order 2
+    )
+    assert pool.free_block_queue.max_order == 2
+    # Span 4 (and 2) are schedulable; at order 0 these would be rejected,
+    # making span>1 groups unschedulable.
+    assert pool.can_allocate_demands({4: 1})
+    assert pool.can_allocate_demands({2: 2})
+
+
+def test_coordinator_sizes_allocator_from_group_spans(monkeypatch):
+    """Regression: enabling buddy on a config whose layout assigned a span>1
+    group must yield a buddy queue able to carve that span, with no manual
+    tuning. The coordinator derives the order from the largest
+    ``allocation_base_span``."""
+    from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
+    from vllm.v1.kv_cache_interface import (
+        FullAttentionSpec,
+        KVCacheConfig,
+        KVCacheGroupSpec,
+    )
+
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    block_size = 2
+    config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+                allocation_base_span=4,
+            )
+        ],
+    )
+    coord = get_kv_cache_coordinator(
+        config,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        use_eagle=False,
+        enable_caching=True,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        scheduler_block_size=block_size,
+        hash_block_size=block_size,
+    )
+    # span 4 -> order 2, derived purely from the config.
+    assert coord.block_pool.free_block_queue.max_order >= 2
+    assert coord.block_pool.can_allocate_demands({4: 1})

--- a/tests/v1/core/test_decoupled_backward_compat.py
+++ b/tests/v1/core/test_decoupled_backward_compat.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Backward compatibility of the decoupled allocator changes (AC-9).
+
+* With the buddy path disabled, the block pool uses the unchanged LRU queue and
+  the baseline allocation behaviour.
+* With the buddy path enabled but every group at span 1 (``max_order == 0``),
+  fresh allocation, the null block, free accounting, and prefix-cache hits
+  match the uniform path.
+
+Note: the buddy queue deliberately links *uncached* free blocks at the head (so
+allocation prefers uncached chunks and preserves cached ones). That makes the
+post-eviction reuse *order* differ from the plain LRU queue; this is a
+heuristic difference, not a correctness one, so it is not asserted here.
+"""
+
+import pytest
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHash, make_block_hash_with_group_id
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_buddy_off_uses_lru_baseline(monkeypatch):
+    monkeypatch.delenv("VLLM_USE_BUDDY_BLOCK_POOL", raising=False)
+    pool = BlockPool(num_gpu_blocks=16, enable_caching=True, hash_block_size=1)
+    assert type(pool.free_block_queue).__name__ == "FreeKVCacheBlockQueue"
+    assert pool.null_block.block_id == 0
+    blocks = pool.get_new_blocks(5)
+    assert [b.block_id for b in blocks] == [1, 2, 3, 4, 5]
+
+
+def test_buddy_span1_matches_uniform_fresh_alloc(monkeypatch):
+    monkeypatch.delenv("VLLM_USE_BUDDY_BLOCK_POOL", raising=False)
+    base = BlockPool(num_gpu_blocks=16, enable_caching=True, hash_block_size=1)
+
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    # No spanned groups -> derived buddy order is 0 (the default); a span-1
+    # buddy pool must behave identically to the uniform LRU pool.
+    buddy = BlockPool(num_gpu_blocks=16, enable_caching=True, hash_block_size=1)
+
+    assert base.null_block.block_id == buddy.null_block.block_id == 0
+    assert base.get_num_free_blocks() == buddy.get_num_free_blocks()
+
+    a = base.get_new_blocks(5)
+    b = buddy.get_new_blocks(5)
+    assert [x.block_id for x in a] == [x.block_id for x in b]
+    assert base.get_num_free_blocks() == buddy.get_num_free_blocks()
+
+
+def test_buddy_span1_cache_hit_cycle(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    pool = BlockPool(num_gpu_blocks=16, enable_caching=True, hash_block_size=1)
+
+    (blk,) = pool.get_new_blocks(1)
+    raw = BlockHash(b"\x07" * 32)
+    key = make_block_hash_with_group_id(raw, 0)
+    blk.block_hash = key
+    pool.cached_block_hash_to_block.insert(key, blk)
+    pool.free_blocks([blk])
+    # A span-1 cached block is a normal prefix-cache hit under the buddy queue.
+    assert pool.get_cached_block(raw, [0]) == [blk]

--- a/tests/v1/core/test_decoupled_layout.py
+++ b/tests/v1/core/test_decoupled_layout.py
@@ -74,7 +74,7 @@ def test_mamba_span_is_allocator_normalized_natural_span(monkeypatch):
     normalize_span produces (the power-of-two rounding now lives there, not in
     the config)."""
     from vllm.utils.math_utils import cdiv
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.buddy_free_queue import BuddyAllocator
 
     monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
     vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
@@ -88,9 +88,7 @@ def test_mamba_span_is_allocator_normalized_natural_span(monkeypatch):
         vllm_config, groups, available_memory=attn.page_size_bytes * 4096
     )
     natural = cdiv(mamba.page_size_bytes, cfg.base_page_bytes)
-    assert groups[1].allocation_base_span == BuddyFreeKVCacheBlockQueue.normalize_span(
-        natural
-    )
+    assert groups[1].allocation_base_span == BuddyAllocator.normalize_span(natural)
 
 
 def test_memory_estimate_uses_same_effective_span_as_layout(monkeypatch):
@@ -98,7 +96,7 @@ def test_memory_estimate_uses_same_effective_span_as_layout(monkeypatch):
     allocator-normalized span the layout assigns, or admission drifts from real
     allocation."""
     from vllm.utils.math_utils import cdiv
-    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.buddy_free_queue import BuddyAllocator
     from vllm.v1.core.kv_cache_utils import _max_memory_usage_bytes_from_groups
 
     monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
@@ -116,7 +114,7 @@ def test_memory_estimate_uses_same_effective_span_as_layout(monkeypatch):
     expected_base_blocks = 0
     for g in groups:
         natural = cdiv(g.kv_cache_spec.page_size_bytes, base_page)
-        effective = BuddyFreeKVCacheBlockQueue.normalize_span(natural)
+        effective = BuddyAllocator.normalize_span(natural)
         logical = cdiv(
             g.kv_cache_spec.max_memory_usage_bytes(vllm_config),
             g.kv_cache_spec.page_size_bytes,

--- a/tests/v1/core/test_decoupled_layout.py
+++ b/tests/v1/core/test_decoupled_layout.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Layout resolution for decoupled hybrid paging.
+
+Verifies the attention-span guard (AC-3): in decoupled mode the base page is
+anchored to the smallest attention page, attention groups must end up at span 1
+so standard-attention strided views stay valid, and a
+non-attention (mamba) group whose native page is larger gets a span > 1. An
+attention group that cannot be represented at the base page is rejected with a
+clear error rather than silently given an unsafe span > 1.
+"""
+
+import pytest
+import torch
+
+from vllm.config import ModelConfig, VllmConfig
+from vllm.v1.core.kv_cache_utils import get_kv_cache_config_from_groups
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheGroupSpec,
+    MambaSpec,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _attn(head_size=64, block_size=16):
+    return FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=2,
+        head_size=head_size,
+        dtype=torch.float32,
+    )
+
+
+def _mamba(block_size=16, shapes=((2, 8192), (3, 128, 128))):
+    return MambaSpec(
+        block_size=block_size,
+        shapes=shapes,
+        dtypes=(torch.float32, torch.float32),
+        num_speculative_blocks=2,
+        mamba_cache_mode="none",
+    )
+
+
+def test_decoupled_attention_span_one_mamba_span_gt_one(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    attn = _attn()
+    mamba = _mamba()
+    # Precondition for a span > 1 mamba group: its native page exceeds the
+    # attention page that becomes the base page.
+    assert mamba.page_size_bytes > attn.page_size_bytes
+
+    groups = [
+        KVCacheGroupSpec(["attn0"], attn),
+        KVCacheGroupSpec(["mamba0"], mamba),
+    ]
+    cfg = get_kv_cache_config_from_groups(
+        vllm_config, groups, available_memory=attn.page_size_bytes * 4096
+    )
+
+    assert cfg.base_page_bytes == attn.page_size_bytes
+    # Attention group is pinned to span 1.
+    assert groups[0].allocation_base_span == 1
+    # Mamba group spans more than one base block, enough to cover its page.
+    assert groups[1].allocation_base_span >= 2
+    assert groups[1].allocation_base_span * cfg.base_page_bytes >= mamba.page_size_bytes
+
+
+def test_mamba_span_is_allocator_normalized_natural_span(monkeypatch):
+    """The layout requests the natural span ceil(page / base_page) and the
+    buddy allocator rounds it; the stored span must equal what the allocator's
+    normalize_span produces (the power-of-two rounding now lives there, not in
+    the config)."""
+    from vllm.utils.math_utils import cdiv
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    attn = _attn()
+    mamba = _mamba()
+    groups = [
+        KVCacheGroupSpec(["attn0"], attn),
+        KVCacheGroupSpec(["mamba0"], mamba),
+    ]
+    cfg = get_kv_cache_config_from_groups(
+        vllm_config, groups, available_memory=attn.page_size_bytes * 4096
+    )
+    natural = cdiv(mamba.page_size_bytes, cfg.base_page_bytes)
+    assert groups[1].allocation_base_span == BuddyFreeKVCacheBlockQueue.normalize_span(
+        natural
+    )
+
+
+def test_memory_estimate_uses_same_effective_span_as_layout(monkeypatch):
+    """The decoupled memory estimate must count base blocks at the same
+    allocator-normalized span the layout assigns, or admission drifts from real
+    allocation."""
+    from vllm.utils.math_utils import cdiv
+    from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+    from vllm.v1.core.kv_cache_utils import _max_memory_usage_bytes_from_groups
+
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    attn = _attn()
+    mamba = _mamba()
+    groups = [
+        KVCacheGroupSpec(["attn0"], attn),
+        KVCacheGroupSpec(["mamba0"], mamba),
+    ]
+    estimate = _max_memory_usage_bytes_from_groups(vllm_config, groups)
+
+    base_page = min(g.kv_cache_spec.page_size_bytes for g in groups)
+    group_size = max(len(g.layer_names) for g in groups)
+    expected_base_blocks = 0
+    for g in groups:
+        natural = cdiv(g.kv_cache_spec.page_size_bytes, base_page)
+        effective = BuddyFreeKVCacheBlockQueue.normalize_span(natural)
+        logical = cdiv(
+            g.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+            g.kv_cache_spec.page_size_bytes,
+        )
+        expected_base_blocks += logical * effective
+    assert estimate == group_size * base_page * expected_base_blocks
+
+
+def test_memory_estimate_anchors_base_page_to_attention_not_smallest(monkeypatch):
+    """Regression: when a non-attention page is SMALLER than the attention
+    page, the base page must still anchor to the smallest *attention* page (as
+    the layout does), not to the smallest page overall. Anchoring to the
+    smaller mamba page would give attention a span > 1 in the estimate while
+    the layout pins it to span 1 — capacity planning would diverge from the
+    realized tensor layout."""
+    from vllm.utils.math_utils import cdiv
+    from vllm.v1.core.kv_cache_utils import _max_memory_usage_bytes_from_groups
+
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    attn = _attn(head_size=512)  # large attention page
+    mamba = _mamba(shapes=((2, 64),))  # tiny mamba page
+    # Precondition: the divergent case the old min(all) rule mishandled.
+    assert mamba.page_size_bytes < attn.page_size_bytes
+
+    groups = [
+        KVCacheGroupSpec(["attn0"], attn),
+        KVCacheGroupSpec(["mamba0"], mamba),
+    ]
+    cfg = get_kv_cache_config_from_groups(
+        vllm_config, groups, available_memory=attn.page_size_bytes * 4096
+    )
+    # Layout anchored to the attention page, NOT the smaller mamba page.
+    assert cfg.base_page_bytes == attn.page_size_bytes
+    assert groups[0].allocation_base_span == 1  # attention pinned to span 1
+
+    # The estimate must agree with the layout: same base page, same per-group
+    # spans (read off the groups the layout just populated).
+    estimate = _max_memory_usage_bytes_from_groups(vllm_config, groups)
+    group_size = max(len(g.layer_names) for g in groups)
+    expected_base_blocks = 0
+    for g in groups:
+        logical = cdiv(
+            g.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+            g.kv_cache_spec.page_size_bytes,
+        )
+        expected_base_blocks += logical * g.allocation_base_span
+    assert estimate == group_size * cfg.base_page_bytes * expected_base_blocks
+
+
+def test_decoupled_max_concurrency_uses_base_page_not_group0(monkeypatch):
+    """Reported capacity (max concurrency / "GPU KV cache size: tokens") must
+    size per-request blocks by the layout's actual ``base_page_bytes``, not
+    ``groups[0]``'s native page. Here group[0] is a mamba group whose native
+    page is far smaller than the base (attention) page — the Kimi-Linear
+    ordering — so reading groups[0]'s page would inflate per-request blocks and
+    under-report capacity by the base/native ratio."""
+    from vllm.utils.math_utils import cdiv
+    from vllm.v1.core.kv_cache_utils import (
+        get_max_concurrency_for_kv_cache_config,
+        max_memory_usage_bytes,
+    )
+
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    mamba = _mamba(shapes=((2, 64),))  # tiny native page
+    attn = _attn(head_size=512)  # large page -> becomes base_page
+    assert mamba.page_size_bytes < attn.page_size_bytes
+    groups = [
+        KVCacheGroupSpec(["mamba0"], mamba),  # group[0]: native << base_page
+        KVCacheGroupSpec(["attn0"], attn),
+    ]
+    cfg = get_kv_cache_config_from_groups(
+        vllm_config, groups, available_memory=attn.page_size_bytes * 4096
+    )
+    assert cfg.base_page_bytes == attn.page_size_bytes
+    # group[0]'s native page differs from base_page, so the buggy formula (read
+    # groups[0]) and the correct one (read base_page) diverge — making the
+    # assertion below meaningful rather than vacuous.
+    assert cfg.kv_cache_groups[0].kv_cache_spec.page_size_bytes != cfg.base_page_bytes
+
+    nlpg = max(len(g.layer_names) for g in cfg.kv_cache_groups)
+    max_mem = nlpg * max_memory_usage_bytes(
+        vllm_config, (g.kv_cache_spec for g in cfg.kv_cache_groups)
+    )
+    expected = cfg.num_blocks / cdiv(max_mem, cfg.base_page_bytes * nlpg)
+    assert get_max_concurrency_for_kv_cache_config(vllm_config, cfg) == expected
+
+
+def test_decoupled_rejects_attention_span_gt_one(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    vllm_config = VllmConfig(model_config=ModelConfig(max_model_len=16))
+    small_attn = _attn(head_size=64)
+    big_attn = _attn(head_size=256)  # larger page than the base (small) attn page
+    assert big_attn.page_size_bytes > small_attn.page_size_bytes
+
+    groups = [
+        KVCacheGroupSpec(["a0"], small_attn),
+        KVCacheGroupSpec(["a1"], big_attn),
+    ]
+    with pytest.raises(ValueError, match="attention"):
+        get_kv_cache_config_from_groups(
+            vllm_config, groups, available_memory=big_attn.page_size_bytes * 4096
+        )

--- a/tests/v1/core/test_decoupled_prefix_cache.py
+++ b/tests/v1/core/test_decoupled_prefix_cache.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Prefix-cache correctness for span>1 (decoupled hybrid) groups (AC-8).
+
+Fragmentation policy: a cached multi-base-block chunk is *preserved* — the
+allocator never coalesces a chunk whose buddy holds a live cache hash, and only
+drops a cached chunk's hash (via the eviction callback) when an allocation must
+reclaim its memory. This keeps the prefix-cache hash map consistent: no stale
+entry survives, and a chunk reused by a new request never carries a previous
+owner's hash (so a cache "hit" can never return reused memory).
+"""
+
+import pytest
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import BlockHash, make_block_hash_with_group_id
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _buddy_pool(monkeypatch, num_gpu_blocks=8, max_order=2):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    return BlockPool(
+        num_gpu_blocks=num_gpu_blocks,
+        enable_caching=True,
+        hash_block_size=1,
+        max_allocation_span=1 << max_order,
+    )
+
+
+def _cache_block(pool, block, raw_hash, group_id=0):
+    key = make_block_hash_with_group_id(raw_hash, group_id)
+    block.block_hash = key
+    pool.cached_block_hash_to_block.insert(key, block)
+
+
+def test_span_block_cache_hit_then_evicted_on_reuse(monkeypatch):
+    pool = _buddy_pool(monkeypatch)
+    raw_hash = BlockHash(b"\x01" * 32)
+
+    # Allocate a span-4 chunk, cache it, and free it back to the pool.
+    (blk,) = pool.get_new_blocks(1, base_span=4)
+    _cache_block(pool, blk, raw_hash)
+    pool.free_blocks([blk])
+
+    # While cached and free, it is a prefix-cache hit and is preserved.
+    assert pool.get_cached_block(raw_hash, [0]) == [blk]
+
+    # Under pressure, the next span-4 allocation must reclaim the cached chunk;
+    # doing so drops its hash (no stale entry) and resets the block.
+    (reused,) = pool.get_new_blocks(1, base_span=4)
+    assert reused.block_id == blk.block_id
+    assert reused.block_hash is None
+    assert pool.get_cached_block(raw_hash, [0]) is None
+
+
+def test_span_block_cache_survives_unrelated_allocation(monkeypatch):
+    # A larger pool so an unrelated span-1 allocation does not need the cached
+    # chunk's memory: the cached chunk must be preserved (no premature evict).
+    pool = _buddy_pool(monkeypatch, num_gpu_blocks=16, max_order=2)
+    raw_hash = BlockHash(b"\x02" * 32)
+
+    (blk,) = pool.get_new_blocks(1, base_span=4)
+    _cache_block(pool, blk, raw_hash)
+    pool.free_blocks([blk])
+    assert pool.get_cached_block(raw_hash, [0]) == [blk]
+
+    # Allocate a few single base blocks elsewhere; the cached span-4 chunk is
+    # untouched and still a hit.
+    others = pool.get_new_blocks(2, base_span=1)
+    assert all(b.block_id != blk.block_id for b in others)
+    assert pool.get_cached_block(raw_hash, [0]) == [blk]
+    assert blk.block_hash is not None

--- a/tests/v1/core/test_eviction_policy.py
+++ b/tests/v1/core/test_eviction_policy.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""LRUEvictionPolicy: the reclaim-candidate store an allocator composes.
+
+Holds released-but-cached blocks in reuse-priority order; ``pop_victim``
+surrenders the least-recently-used candidate after firing ``on_evict`` to drop
+its hash; ``untrack`` removes a specific candidate on a prefix-cache hit.
+"""
+
+import pytest
+
+from vllm.v1.core.eviction_policy import LRUEvictionPolicy
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _blk(i, span=1):
+    b = KVCacheBlock(i)
+    b.base_span = span
+    return b
+
+
+def test_track_untrack_accounting():
+    ev = LRUEvictionPolicy()
+    a, b = _blk(1), _blk(2, span=4)
+    ev.track(a)
+    ev.track(b)
+    assert ev.num_reclaimable == 1 + 4
+    assert set(x.block_id for x in ev.reclaimable_chunks()) == {1, 2}
+    ev.untrack(a)
+    assert ev.num_reclaimable == 4
+    assert a.prev_free_block is None and a.next_free_block is None
+
+
+def test_pop_victim_is_lru_order():
+    ev = LRUEvictionPolicy()
+    first, second, third = _blk(10), _blk(11), _blk(12)
+    ev.track(first)
+    ev.track(second)
+    ev.track(third)
+    # Oldest (first tracked) is reclaimed first.
+    assert ev.pop_victim().block_id == 10
+    assert ev.pop_victim().block_id == 11
+    assert ev.pop_victim().block_id == 12
+    assert ev.pop_victim() is None
+
+
+def test_prefer_reuse_reclaimed_first():
+    ev = LRUEvictionPolicy()
+    ev.track(_blk(10))
+    ev.track(_blk(11))
+    ev.track(_blk(12), prefer_reuse=True)  # jump to the reclaim-soon end
+    assert ev.pop_victim().block_id == 12
+    assert ev.pop_victim().block_id == 10
+
+
+def test_pop_victim_fires_on_evict_and_updates_count():
+    evicted = []
+
+    def on_evict(block):
+        evicted.append(block.block_id)
+        block.reset_hash()
+        return True
+
+    ev = LRUEvictionPolicy(on_evict=on_evict)
+    b = _blk(7, span=2)
+    b.block_hash = ("h", 7)
+    ev.track(b)
+    assert ev.num_reclaimable == 2
+    victim = ev.pop_victim()
+    assert victim is b
+    assert evicted == [7]
+    assert b.block_hash is None  # on_evict reset it
+    assert ev.num_reclaimable == 0
+
+
+def test_untrack_unknown_block_raises():
+    ev = LRUEvictionPolicy()
+    with pytest.raises(RuntimeError):
+        ev.untrack(_blk(99))

--- a/tests/v1/core/test_kv_cache_allocator_interface.py
+++ b/tests/v1/core/test_kv_cache_allocator_interface.py
@@ -1,19 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""The allocator-neutral KVCacheBlockAllocator interface (AC-5).
+"""The allocator-neutral BlockAllocator interface (AC-5).
 
 Both built-in allocators satisfy the runtime-checkable interface, a fresh
 third-party allocator with no buddy concepts can satisfy it, and the generic
 KV-cache surface (group spec, coordinator, manager) names no allocator-specific
-concepts.
+concepts. Prefix-cache eviction is a separate concern behind ``EvictionPolicy``.
 """
 
 import inspect
 
 import pytest
 
-from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
-from vllm.v1.core.kv_cache_allocator import KVCacheBlockAllocator
+from vllm.v1.core.buddy_free_queue import BuddyAllocator
+from vllm.v1.core.eviction_policy import LRUEvictionPolicy
+from vllm.v1.core.kv_cache_allocator import BlockAllocator, EvictionPolicy
 from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
 
 pytestmark = pytest.mark.cpu_test
@@ -21,19 +22,27 @@ pytestmark = pytest.mark.cpu_test
 
 def test_both_builtin_allocators_satisfy_protocol():
     lru = FreeKVCacheBlockQueue([KVCacheBlock(i) for i in range(8)])
-    buddy = BuddyFreeKVCacheBlockQueue([KVCacheBlock(i) for i in range(8)], max_order=2)
-    assert isinstance(lru, KVCacheBlockAllocator)
-    assert isinstance(buddy, KVCacheBlockAllocator)
+    buddy = BuddyAllocator(
+        [KVCacheBlock(i) for i in range(8)],
+        max_order=2,
+        evictor=LRUEvictionPolicy(),
+    )
+    assert isinstance(lru, BlockAllocator)
+    assert isinstance(buddy, BlockAllocator)
+
+
+def test_lru_eviction_policy_satisfies_protocol():
+    assert isinstance(LRUEvictionPolicy(), EvictionPolicy)
 
 
 def test_incomplete_allocator_is_not_an_instance():
     class Partial:
         num_free_blocks = 0
 
-        def popleft(self):  # missing the rest of the surface
+        def allocate(self, span=1):  # missing the rest of the surface
             ...
 
-    assert not isinstance(Partial(), KVCacheBlockAllocator)
+    assert not isinstance(Partial(), BlockAllocator)
 
 
 def test_trivial_third_party_allocator_conforms():
@@ -45,41 +54,21 @@ def test_trivial_third_party_allocator_conforms():
             self._free = list(blocks)
             self.num_free_blocks = len(blocks)
 
-        def popleft(self):
+        def allocate(self, span=1):
+            if span != 1:
+                raise ValueError("only span 1")
             self.num_free_blocks -= 1
             return self._free.pop()
 
-        def popleft_n(self, n):
-            return [self.popleft() for _ in range(n)]
-
-        def append(self, block):
+        def free(self, block, *, prefer_reuse=False):
             self._free.append(block)
             self.num_free_blocks += 1
 
-        def append_n(self, blocks):
-            for block in blocks:
-                self.append(block)
-
-        def prepend_n(self, blocks):
-            for block in blocks:
-                self.append(block)
-
-        def remove(self, block):
+        def reuse(self, block):
             self._free.remove(block)
             self.num_free_blocks -= 1
 
-        def get_all_free_blocks(self):
-            return list(self._free)
-
-        def allocate_spanned_block(self, base_span):
-            if base_span != 1:
-                raise ValueError("only span 1")
-            return self.popleft()
-
-        def free_spanned_block(self, block):
-            self.append(block)
-
-        def can_allocate_spans(self, demand_by_span):
+        def can_allocate(self, demand_by_span):
             return all(s == 1 for s, c in demand_by_span.items() if c > 0) and (
                 sum(demand_by_span.values()) <= self.num_free_blocks
             )
@@ -91,7 +80,7 @@ def test_trivial_third_party_allocator_conforms():
             raise ValueError("only span 1")
 
     alloc = TrivialAllocator([KVCacheBlock(i) for i in range(4)])
-    assert isinstance(alloc, KVCacheBlockAllocator)
+    assert isinstance(alloc, BlockAllocator)
 
 
 def test_generic_surface_has_no_allocator_specific_names():

--- a/tests/v1/core/test_kv_cache_allocator_interface.py
+++ b/tests/v1/core/test_kv_cache_allocator_interface.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""The allocator-neutral KVCacheBlockAllocator interface (AC-5).
+
+Both built-in allocators satisfy the runtime-checkable interface, a fresh
+third-party allocator with no buddy concepts can satisfy it, and the generic
+KV-cache surface (group spec, coordinator, manager) names no allocator-specific
+concepts.
+"""
+
+import inspect
+
+import pytest
+
+from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+from vllm.v1.core.kv_cache_allocator import KVCacheBlockAllocator
+from vllm.v1.core.kv_cache_utils import FreeKVCacheBlockQueue, KVCacheBlock
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_both_builtin_allocators_satisfy_protocol():
+    lru = FreeKVCacheBlockQueue([KVCacheBlock(i) for i in range(8)])
+    buddy = BuddyFreeKVCacheBlockQueue([KVCacheBlock(i) for i in range(8)], max_order=2)
+    assert isinstance(lru, KVCacheBlockAllocator)
+    assert isinstance(buddy, KVCacheBlockAllocator)
+
+
+def test_incomplete_allocator_is_not_an_instance():
+    class Partial:
+        num_free_blocks = 0
+
+        def popleft(self):  # missing the rest of the surface
+            ...
+
+    assert not isinstance(Partial(), KVCacheBlockAllocator)
+
+
+def test_trivial_third_party_allocator_conforms():
+    """A minimal allocator with no buddy concepts satisfies the interface and
+    can therefore back a BlockPool."""
+
+    class TrivialAllocator:
+        def __init__(self, blocks):
+            self._free = list(blocks)
+            self.num_free_blocks = len(blocks)
+
+        def popleft(self):
+            self.num_free_blocks -= 1
+            return self._free.pop()
+
+        def popleft_n(self, n):
+            return [self.popleft() for _ in range(n)]
+
+        def append(self, block):
+            self._free.append(block)
+            self.num_free_blocks += 1
+
+        def append_n(self, blocks):
+            for block in blocks:
+                self.append(block)
+
+        def prepend_n(self, blocks):
+            for block in blocks:
+                self.append(block)
+
+        def remove(self, block):
+            self._free.remove(block)
+            self.num_free_blocks -= 1
+
+        def get_all_free_blocks(self):
+            return list(self._free)
+
+        def allocate_spanned_block(self, base_span):
+            if base_span != 1:
+                raise ValueError("only span 1")
+            return self.popleft()
+
+        def free_spanned_block(self, block):
+            self.append(block)
+
+        def can_allocate_spans(self, demand_by_span):
+            return all(s == 1 for s, c in demand_by_span.items() if c > 0) and (
+                sum(demand_by_span.values()) <= self.num_free_blocks
+            )
+
+        @staticmethod
+        def normalize_span(natural_span):
+            if natural_span <= 1:
+                return 1
+            raise ValueError("only span 1")
+
+    alloc = TrivialAllocator([KVCacheBlock(i) for i in range(4)])
+    assert isinstance(alloc, KVCacheBlockAllocator)
+
+
+def test_generic_surface_has_no_allocator_specific_names():
+    """The group spec, coordinator, and single-type manager must not name
+    allocator-implementation concepts (buddy order, chunk_order, alloc_chunk,
+    bit-shift translation)."""
+    import vllm.v1.core.kv_cache_coordinator as coordinator_mod
+    import vllm.v1.core.single_type_kv_cache_manager as manager_mod
+    import vllm.v1.kv_cache_interface as interface_mod
+
+    forbidden = ("chunk_order", "alloc_chunk", "buddy_order", "_buddy_order")
+    for mod in (interface_mod, coordinator_mod, manager_mod):
+        src = inspect.getsource(mod)
+        for token in forbidden:
+            assert token not in src, f"{token!r} found in {mod.__name__}"

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -3903,3 +3903,41 @@ def test_pure_swa_retention_dense_default_caches_all(monkeypatch):
         is not None
     }
     assert cached == set(range(16))
+
+
+def test_mamba_reachable_block_mask_sparsifies_retention():
+    """Mamba state-snapshot retention: with VLLM_PREFIX_CACHE_RETENTION_INTERVAL
+    the manager keeps one cached state per interval-sized segment (plus the
+    latest replay boundary) instead of a snapshot per block, which is what
+    lets a small attention block_size avoid Mamba dominating the KV pool."""
+    from vllm.v1.core.single_type_kv_cache_manager import MambaManager
+
+    block_size = 16
+    spec = MambaSpec(
+        block_size=block_size,
+        shapes=(1, 1),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+
+    def retained(retention_interval, num_prompt_tokens=256, end_block=16):
+        m = MambaManager.reachable_block_mask(
+            start_block=0,
+            end_block=end_block,
+            alignment_tokens=block_size,
+            kv_cache_spec=spec,
+            use_eagle=False,
+            retention_interval=retention_interval,
+            num_prompt_tokens=num_prompt_tokens,
+        )
+        return None if m is None else {i for i, v in enumerate(m) if v}
+
+    # Dense default (None) -> no mask, every block cached (unchanged behavior).
+    assert retained(None) is None
+    # interval == block_size -> every block is a boundary -> stays dense.
+    assert retained(block_size) is None
+    # interval 64 = 4 blocks: segment tails at i%4==3 -> {3,7,11,15}; latest
+    # replay boundary 240//16 - 1 = 14. Sparse subset of the 16 blocks.
+    assert retained(64) == {3, 7, 11, 14, 15}
+    # interval 0 -> only the latest replay boundary (block 14).
+    assert retained(0) == {14}

--- a/tests/v1/core/test_span_normalization.py
+++ b/tests/v1/core/test_span_normalization.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Allocator-owned span normalization.
+
+The decoupled layout requests a *natural* span (base blocks a group's page
+needs); the allocator rounds it to a granularity it can carve and align. This
+keeps the power-of-two rounding inside the buddy allocator instead of inlined in
+the config, so a span-capable allocator could realize a natural span with no
+waste. These tests pin the rounding policy of each built-in allocator and the
+resolver the config uses to pick one.
+"""
+
+import pytest
+
+from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+from vllm.v1.core.kv_cache_utils import (
+    FreeKVCacheBlockQueue,
+    KVCacheBlock,
+    _active_span_normalizer,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+@pytest.mark.parametrize(
+    "natural,expected",
+    [(1, 1), (2, 2), (3, 4), (4, 4), (5, 8), (8, 8), (9, 16)],
+)
+def test_buddy_normalize_span_rounds_to_power_of_two(natural, expected):
+    assert BuddyFreeKVCacheBlockQueue.normalize_span(natural) == expected
+
+
+def test_lru_normalize_span_only_supports_span_one():
+    assert FreeKVCacheBlockQueue.normalize_span(1) == 1
+    assert FreeKVCacheBlockQueue.normalize_span(0) == 1
+    for natural in (2, 3, 5):
+        with pytest.raises(ValueError, match="span"):
+            FreeKVCacheBlockQueue.normalize_span(natural)
+
+
+def test_active_span_normalizer_follows_buddy_flag(monkeypatch):
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
+    assert _active_span_normalizer() is BuddyFreeKVCacheBlockQueue.normalize_span
+    monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "0")
+    assert _active_span_normalizer() is FreeKVCacheBlockQueue.normalize_span
+
+
+def test_buddy_alloc_records_normalized_span_on_block():
+    # A chunk handed out at order k carries base_span == 2**k, the neutral
+    # base-block count the rename exposes (no buddy "order" on the block).
+    blocks = [KVCacheBlock(i) for i in range(16)]
+    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
+    head = q.alloc_chunk(order=2)
+    assert head.base_span == 4
+    assert head.base_span == BuddyFreeKVCacheBlockQueue.normalize_span(3)

--- a/tests/v1/core/test_span_normalization.py
+++ b/tests/v1/core/test_span_normalization.py
@@ -12,7 +12,7 @@ resolver the config uses to pick one.
 
 import pytest
 
-from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+from vllm.v1.core.buddy_free_queue import BuddyAllocator
 from vllm.v1.core.kv_cache_utils import (
     FreeKVCacheBlockQueue,
     KVCacheBlock,
@@ -27,7 +27,7 @@ pytestmark = pytest.mark.cpu_test
     [(1, 1), (2, 2), (3, 4), (4, 4), (5, 8), (8, 8), (9, 16)],
 )
 def test_buddy_normalize_span_rounds_to_power_of_two(natural, expected):
-    assert BuddyFreeKVCacheBlockQueue.normalize_span(natural) == expected
+    assert BuddyAllocator.normalize_span(natural) == expected
 
 
 def test_lru_normalize_span_only_supports_span_one():
@@ -40,16 +40,16 @@ def test_lru_normalize_span_only_supports_span_one():
 
 def test_active_span_normalizer_follows_buddy_flag(monkeypatch):
     monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "1")
-    assert _active_span_normalizer() is BuddyFreeKVCacheBlockQueue.normalize_span
+    assert _active_span_normalizer() is BuddyAllocator.normalize_span
     monkeypatch.setenv("VLLM_USE_BUDDY_BLOCK_POOL", "0")
     assert _active_span_normalizer() is FreeKVCacheBlockQueue.normalize_span
 
 
 def test_buddy_alloc_records_normalized_span_on_block():
-    # A chunk handed out at order k carries base_span == 2**k, the neutral
-    # base-block count the rename exposes (no buddy "order" on the block).
+    # A chunk handed out at span 2**k carries base_span == 2**k, the neutral
+    # base-block count the interface exposes (no buddy "order" on the block).
     blocks = [KVCacheBlock(i) for i in range(16)]
-    q = BuddyFreeKVCacheBlockQueue(blocks, max_order=4)
-    head = q.alloc_chunk(order=2)
+    q = BuddyAllocator(blocks, max_order=4)
+    head = q.allocate(4)
     assert head.base_span == 4
-    assert head.base_span == BuddyFreeKVCacheBlockQueue.normalize_span(3)
+    assert head.base_span == BuddyAllocator.normalize_span(3)

--- a/tests/v1/e2e/decoupled_hybrid_runner.py
+++ b/tests/v1/e2e/decoupled_hybrid_runner.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Worker for the decoupled hybrid-paging end-to-end parity test (AC-10).
+
+Run in its own process (the model is loaded with tensor parallelism, so each
+configuration needs a clean engine lifecycle). Selected by env vars:
+
+    DECOUPLED_E2E_MODE=baseline|decoupled
+    DECOUPLED_E2E_MODEL=<hf id or local path>
+    DECOUPLED_E2E_TP=<tensor parallel size>
+    DECOUPLED_E2E_OUT=<json output path>
+    DECOUPLED_E2E_BS=<attn block size, default 64>
+
+In ``decoupled`` mode it sets VLLM_USE_BUDDY_BLOCK_POOL=1 *before* importing
+vLLM, so the buddy allocator and decoupled-page layout are active (the buddy
+order is derived from the layout, no manual knob). Both modes use the same attn
+block_size so the comparison isolates the
+allocator (the buddy changes allocation, not numerics). It generates greedily
+on a fixed prompt set TWICE (pass-2 must reuse the prefix cache and match
+pass-1) and writes outputs to JSON for the parent test to compare.
+
+block_size=64 keeps FlashInfer-MLA's tile-alignment divisor at 2, avoiding the
+``block_num % (128/block_size) == 0`` decode-kernel constraint that fires at
+the default block_size=32 on SM10 (see current-work/FLASHINFER_BLOCK_NUM_CHECK.md).
+"""
+
+import json
+import os
+
+SHARED = (
+    "You are a meticulous assistant. Read the following context carefully "
+    "before answering.\nContext: The Apollo program ran from 1961 to 1972 and "
+    "landed twelve astronauts on the Moon across six successful missions.\n\n"
+)
+PROMPTS = [
+    "The capital of France is",
+    "Compute 17 * 23. Show the result as a single integer.",
+    "List three primary colors, one per line, no other text.",
+    "The secret word is 'platypus'. Write one sentence about the weather, "
+    "then on a new line repeat the secret word.",
+    SHARED + "Question: In what year did the Apollo program end? "
+    "Answer with just the year.",
+    SHARED + "Question: How many astronauts landed on the Moon? "
+    "Answer with a single word or number.",
+]
+
+
+def main() -> None:
+    mode = os.environ["DECOUPLED_E2E_MODE"]
+    model = os.environ["DECOUPLED_E2E_MODEL"]
+    tp = int(os.environ.get("DECOUPLED_E2E_TP", "4"))
+    out_path = os.environ["DECOUPLED_E2E_OUT"]
+    block_size = int(os.environ.get("DECOUPLED_E2E_BS", "64"))
+
+    if mode == "decoupled":
+        # Enable the buddy allocator + decoupled-page layout. We deliberately do
+        # NOT set VLLM_BUDDY_MAX_ORDER: the coordinator derives the buddy order
+        # from the layout's per-group spans, so this exercises that
+        # auto-derivation end to end (the test used to mask the missing
+        # derivation by pinning the order here).
+        os.environ["VLLM_USE_BUDDY_BLOCK_POOL"] = "1"
+    else:
+        # Force baseline explicitly OFF so it cannot inherit a stray enable from
+        # the ambient environment, which would collapse the A/B.
+        os.environ["VLLM_USE_BUDDY_BLOCK_POOL"] = "0"
+
+    # Import only after env is set so the flags are read at startup.
+    from vllm import LLM, SamplingParams
+
+    llm = LLM(
+        model=model,
+        tensor_parallel_size=tp,
+        trust_remote_code=True,
+        enforce_eager=True,
+        max_model_len=8192,
+        gpu_memory_utilization=0.90,
+        enable_prefix_caching=True,
+        block_size=block_size,
+    )
+
+    cache_cfg = llm.llm_engine.vllm_config.cache_config
+    info = {
+        "mode": mode,
+        # The allocator flag this run actually saw (captured after the mode
+        # block sets it). The parent test asserts baseline=off / decoupled=on so
+        # the A/B can't be silently collapsed by an ambient env var.
+        "buddy_enabled": os.environ.get("VLLM_USE_BUDDY_BLOCK_POOL") == "1",
+        "block_size": cache_cfg.block_size,
+        # num_gpu_blocks is the cross-process-visible proof that the decoupled
+        # layout engaged: reinterpreting the id space at the smaller base page
+        # yields strictly more base blocks than the uniform baseline. The
+        # kv_cache_config (and base_page_bytes) lives in the engine-core process
+        # under TP and is not readable from this driver process.
+        "num_gpu_blocks": cache_cfg.num_gpu_blocks,
+        "mamba_block_size": getattr(cache_cfg, "mamba_block_size", None),
+        "mamba_cache_mode": getattr(cache_cfg, "mamba_cache_mode", None),
+    }
+
+    tok = llm.get_tokenizer()
+    prompts = PROMPTS
+    if getattr(tok, "chat_template", None):
+        prompts = [
+            tok.apply_chat_template(
+                [{"role": "user", "content": p}],
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+            for p in PROMPTS
+        ]
+
+    greedy = SamplingParams(temperature=0.0, max_tokens=48, seed=0)
+
+    def run(engine):
+        outs = engine.generate(prompts, greedy)
+        return [
+            {"text": o.outputs[0].text, "token_ids": list(o.outputs[0].token_ids)}
+            for o in outs
+        ]
+
+    pass1 = run(llm)
+    pass2 = run(llm)  # must hit the prefix cache and match pass-1
+
+    with open(out_path, "w") as f:
+        json.dump({"info": info, "pass1": pass1, "pass2": pass2}, f)
+    print(f"[{mode}] wrote {out_path} (bs={info['block_size']})", flush=True)
+
+    # Release GPU memory and the tensor-parallel workers before exit so a
+    # subsequent run (the parent test loads baseline then decoupled
+    # sequentially) does not start against a still-occupied device.
+    del llm
+    from vllm.distributed import cleanup_dist_env_and_memory
+
+    cleanup_dist_env_and_memory()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/v1/e2e/test_decoupled_hybrid_parity.py
+++ b/tests/v1/e2e/test_decoupled_hybrid_parity.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end parity for decoupled hybrid paging on a real model (AC-10).
+
+Runs a real attention + linear-attention/Mamba hybrid model — Kimi-Linear by
+default — twice: once with the uniform-page baseline and once with the
+decoupled buddy allocator enabled as a supported config, at the SAME attn
+block size. The buddy changes allocation, not numerics, so greedy generations
+must match the baseline token-for-token (allowing at most one prompt of
+MoE/atomics nondeterminism), prefix-cache reuse must be exact (pass-2 ==
+pass-1), and known-answer sanity must hold.
+
+This is a GPU end-to-end test: it loads a large model with tensor parallelism,
+so it is skipped unless GPUs and the model are available. Each configuration
+runs in its own subprocess (clean TP engine lifecycle per config). Override the
+model with DECOUPLED_E2E_MODEL, TP with DECOUPLED_E2E_TP, and attn block size
+with DECOUPLED_E2E_BS (default 64; 64 keeps FlashInfer-MLA's tile-alignment
+divisor at 2, avoiding the block_num%(128/block_size)==0 decode constraint).
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+MODEL = os.environ.get("DECOUPLED_E2E_MODEL", "moonshotai/Kimi-Linear-48B-A3B-Instruct")
+TP = int(os.environ.get("DECOUPLED_E2E_TP", "4"))
+BS = os.environ.get("DECOUPLED_E2E_BS", "64")
+RUNNER = os.path.join(os.path.dirname(__file__), "decoupled_hybrid_runner.py")
+
+# Known-answer checks: (prompt_index, accepted lowercase substrings).
+SANITY = [(0, ["paris"]), (1, ["391"]), (4, ["1972"]), (5, ["twelve", "12"])]
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or torch.cuda.device_count() < TP,
+    reason=f"requires >= {TP} GPUs",
+)
+
+
+def _run(mode: str, out_path: str) -> dict:
+    env = {
+        **os.environ,
+        "DECOUPLED_E2E_MODE": mode,
+        "DECOUPLED_E2E_MODEL": MODEL,
+        "DECOUPLED_E2E_TP": str(TP),
+        "DECOUPLED_E2E_BS": BS,
+        "DECOUPLED_E2E_OUT": out_path,
+    }
+    subprocess.run([sys.executable, RUNNER], env=env, check=True, timeout=3600)
+    with open(out_path) as f:
+        return json.load(f)
+
+
+def _token_diffs(a: list[dict], b: list[dict]) -> list[int]:
+    return [i for i, (x, y) in enumerate(zip(a, b)) if x["token_ids"] != y["token_ids"]]
+
+
+@pytest.mark.timeout(7800)
+def test_decoupled_hybrid_matches_uniform_baseline():
+    with tempfile.TemporaryDirectory() as d:
+        base = _run("baseline", os.path.join(d, "baseline.json"))
+        dec = _run("decoupled", os.path.join(d, "decoupled.json"))
+
+    # The two runs must differ in allocator as intended: baseline must not have
+    # inherited a stray buddy enable from the environment, and decoupled must
+    # have it on.
+    assert base["info"]["buddy_enabled"] is False
+    assert dec["info"]["buddy_enabled"] is True
+
+    # The decoupled run must actually engage the decoupled layout, not silently
+    # fall back. Reinterpreting the id space at the smaller base page yields
+    # STRICTLY more base blocks than the uniform baseline (Mamba no longer
+    # inflates the page). A fallback would leave the counts equal, so `>` — not
+    # `>=` — is what proves activation.
+    assert dec["info"]["num_gpu_blocks"] > base["info"]["num_gpu_blocks"], (
+        f"decoupled num_gpu_blocks ({dec['info']['num_gpu_blocks']}) is not "
+        f"greater than baseline ({base['info']['num_gpu_blocks']}); the "
+        "decoupled layout likely did not activate (silent fallback)."
+    )
+
+    # Prefix-cache reuse must be exact under both allocators.
+    assert not _token_diffs(base["pass1"], base["pass2"])
+    assert not _token_diffs(dec["pass1"], dec["pass2"])
+
+    # Decoupled generations match the uniform baseline token-for-token (allow
+    # at most one prompt of MoE/atomics nondeterminism at this scale).
+    diffs = _token_diffs(base["pass1"], dec["pass1"])
+    assert len(diffs) <= 1, "decoupled diverged from baseline on prompts " + ", ".join(
+        f"{i}: base={base['pass1'][i]['text']!r} dec={dec['pass1'][i]['text']!r}"
+        for i in diffs
+    )
+
+    # Known-answer sanity on the decoupled run.
+    bad = [
+        i
+        for i, accepts in SANITY
+        if not any(s in dec["pass1"][i]["text"].lower() for s in accepts)
+    ]
+    assert not bad, f"decoupled failed known-answer sanity on prompts {bad}"

--- a/tests/v1/worker/test_variable_block_slot_mapping.py
+++ b/tests/v1/worker/test_variable_block_slot_mapping.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Slot mapping correctness under hybrid_blocks (per-group order > 0).
+
+When kernel_block_size < block_size, the BlockTable expands one kv_manager
+block id into ``blocks_per_kv_block = 2^order`` consecutive kernel block ids,
+and the slot mapping kernel uses kernel_block_size as the row stride
+(equivalently, tokens_per_row). For an allocated chunk at start row
+``r0 = kv_manager_id * 2^order`` covering ``block_size`` tokens, the
+expected slot for position ``p`` (within the request) is::
+
+    lb     = p // block_size
+    off    = p % block_size
+    row    = block_table_kernel[req, lb*2^order + off // kbs]
+    slot   = row * kernel_block_size + (off % kernel_block_size)
+
+This file verifies that the existing _compute_slot_mapping_kernel through the
+BlockTable hybrid_blocks path produces these slot ids exactly for several
+orders. No new kernel is introduced — the test pins down the contract we lean
+on when wiring buddy + per-group order on top.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.v1.attention.backends.utils import PAD_SLOT_ID
+from vllm.v1.worker.block_table import BlockTable
+
+DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+
+
+def _expected_slots(
+    positions: np.ndarray,
+    kv_manager_ids: list[int],
+    block_size: int,
+    kernel_block_size: int,
+) -> np.ndarray:
+    """Reference computation matching the hybrid_blocks contract."""
+    blocks_per_kv_block = block_size // kernel_block_size
+    kernel_ids = []
+    for kv_id in kv_manager_ids:
+        for k in range(blocks_per_kv_block):
+            kernel_ids.append(kv_id * blocks_per_kv_block + k)
+    kernel_ids_np = np.asarray(kernel_ids, dtype=np.int64)
+    out = np.empty_like(positions, dtype=np.int64)
+    for i, p in enumerate(positions):
+        row_idx = p // kernel_block_size
+        within = p % kernel_block_size
+        out[i] = kernel_ids_np[row_idx] * kernel_block_size + within
+    return out
+
+
+def _make_block_table(
+    block_size: int, kernel_block_size: int, max_num_blocks_per_req: int = 16
+) -> BlockTable:
+    return BlockTable(
+        block_size=block_size,
+        max_num_reqs=4,
+        max_num_blocks_per_req=max_num_blocks_per_req,
+        max_num_batched_tokens=4096,
+        pin_memory=False,
+        device=torch.device(DEVICE),
+        kernel_block_size=kernel_block_size,
+        cp_kv_cache_interleave_size=1,
+    )
+
+
+@pytest.mark.skipif(DEVICE != "cuda", reason="Triton kernel requires CUDA")
+@pytest.mark.parametrize(
+    "block_size, kernel_block_size",
+    [
+        (16, 16),  # order = 0, uniform (no hybrid)
+        (32, 16),  # order = 1
+        (64, 16),  # order = 2
+        (128, 16),  # order = 3
+        (256, 16),  # order = 4
+    ],
+)
+def test_slot_mapping_hybrid_order(block_size: int, kernel_block_size: int) -> None:
+    bt = _make_block_table(block_size, kernel_block_size)
+
+    # Single request, 3 kv_manager blocks → expanded to 3 * 2^order rows.
+    kv_manager_ids = [4, 7, 12]
+    bt.append_row(kv_manager_ids, row_idx=0)
+    bt.commit_block_table(num_reqs=1)
+
+    num_tokens = 3 * block_size
+    positions = torch.arange(num_tokens, device=DEVICE, dtype=torch.int64)
+    qsl = torch.tensor([0, num_tokens], device=DEVICE, dtype=torch.int32)
+
+    bt.compute_slot_mapping(num_reqs=1, query_start_loc=qsl, positions=positions)
+    got = bt.slot_mapping.gpu[:num_tokens].cpu().numpy()
+
+    expected = _expected_slots(
+        positions.cpu().numpy(),
+        kv_manager_ids,
+        block_size,
+        kernel_block_size,
+    )
+    assert np.array_equal(got, expected), (
+        f"Slot mismatch for block_size={block_size}, "
+        f"kernel_block_size={kernel_block_size}: "
+        f"expected[:8]={expected[:8]}, got[:8]={got[:8]}"
+    )
+
+
+@pytest.mark.skipif(DEVICE != "cuda", reason="Triton kernel requires CUDA")
+def test_slot_mapping_hybrid_pad_region() -> None:
+    """Tokens past num_tokens must be padded to PAD_SLOT_ID."""
+    block_size, kernel_block_size = 64, 16
+    bt = _make_block_table(block_size, kernel_block_size)
+    bt.append_row([1, 2], row_idx=0)
+    bt.commit_block_table(num_reqs=1)
+
+    num_tokens = 5
+    positions = torch.arange(num_tokens, device=DEVICE, dtype=torch.int64)
+    qsl = torch.tensor([0, num_tokens], device=DEVICE, dtype=torch.int32)
+    bt.compute_slot_mapping(num_reqs=1, query_start_loc=qsl, positions=positions)
+    sm = bt.slot_mapping.gpu.cpu().numpy()
+    # First num_tokens are real; the tail is padded.
+    assert (sm[num_tokens:] == PAD_SLOT_ID).all()
+
+
+@pytest.mark.skipif(DEVICE != "cuda", reason="Triton kernel requires CUDA")
+def test_slot_mapping_hybrid_multi_request() -> None:
+    """Multiple requests with different lengths land in correct slot ranges."""
+    block_size, kernel_block_size = 64, 16  # order = 2
+    bt = _make_block_table(block_size, kernel_block_size)
+    bt.append_row([3, 9], row_idx=0)  # 128 tokens of capacity
+    bt.append_row([5], row_idx=1)  # 64 tokens of capacity
+    bt.commit_block_table(num_reqs=2)
+
+    lens = [80, 40]
+    positions_list = []
+    for length in lens:
+        positions_list.append(torch.arange(length, dtype=torch.int64))
+    positions = torch.cat(positions_list).to(DEVICE)
+    qsl = torch.tensor([0, lens[0], lens[0] + lens[1]],
+                       device=DEVICE, dtype=torch.int32)
+
+    bt.compute_slot_mapping(num_reqs=2, query_start_loc=qsl, positions=positions)
+    got = bt.slot_mapping.gpu[: sum(lens)].cpu().numpy()
+
+    expected0 = _expected_slots(
+        np.arange(lens[0]), [3, 9], block_size, kernel_block_size
+    )
+    expected1 = _expected_slots(
+        np.arange(lens[1]), [5], block_size, kernel_block_size
+    )
+    expected = np.concatenate([expected0, expected1])
+    assert np.array_equal(got, expected), (
+        f"Multi-req slot mismatch: expected[:8]={expected[:8]} "
+        f"got[:8]={got[:8]}"
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/decode_bench_connector.py
@@ -387,40 +387,28 @@ class DecodeBenchConnectorWorker:
 
             kv_cache = self.kv_caches[layer_name]
 
-            # Convert block_ids to tensor on device
-            block_ids_tensor = torch.tensor(
-                block_ids, dtype=torch.long, device=kv_cache.device
-            )
-
-            # Filter invalid block IDs
-            valid_mask = block_ids_tensor < kv_cache.shape[0]
-            valid_block_ids = block_ids_tensor[valid_mask]
-
-            if len(valid_block_ids) == 0:
-                continue
-
-            # Create fill values - either constant or random
-            block_shape = kv_cache.shape[1:]
-            if self.fill_std > 0:
-                # Random normal sampling
-                fill_values = torch.normal(
-                    mean=self.fill_mean,
-                    std=self.fill_std,
-                    size=(len(valid_block_ids),) + block_shape,
-                    dtype=kv_cache.dtype,
-                    device=kv_cache.device,
-                )
+            # Attention layers store KV as a single block-indexed tensor whose
+            # first dim is num_blocks; fill the requested block rows. Hybrid /
+            # linear-attention layers (e.g. Mamba, Kimi Delta Attention) store
+            # their state as a list/tuple of tensors that are NOT block-indexed
+            # — each tensor is a single state buffer with no num_blocks
+            # dimension — so fill each tensor in its entirety with the same
+            # dummy values.
+            if isinstance(kv_cache, torch.Tensor):
+                self._fill_block_tensor(kv_cache, block_ids)
+            elif isinstance(kv_cache, (list, tuple)) and all(
+                isinstance(t, torch.Tensor) for t in kv_cache
+            ):
+                for state_tensor in kv_cache:
+                    self._fill_state_tensor(state_tensor)
             else:
-                # Constant fill value
-                fill_values = torch.full(
-                    (len(valid_block_ids),) + block_shape,
-                    self.fill_mean,
-                    dtype=kv_cache.dtype,
-                    device=kv_cache.device,
+                logger.warning_once(
+                    "DecodeBenchConnector: skipping fill for layer %s whose KV "
+                    "cache is %s, not a tensor or a list/tuple of tensors.",
+                    layer_name,
+                    type(kv_cache).__name__,
                 )
-
-            # Batch fill operation
-            kv_cache[valid_block_ids] = fill_values
+                continue
 
         logger.debug(
             "DecodeBenchConnector: Filled %d blocks in group %d with %s values "
@@ -431,3 +419,62 @@ class DecodeBenchConnectorWorker:
             self.fill_mean,
             self.fill_std,
         )
+
+    def _fill_block_tensor(self, kv_cache: torch.Tensor, block_ids: list[int]):
+        """Fill the requested block rows of a block-indexed KV cache tensor.
+
+        Args:
+            kv_cache: A KV cache tensor whose first dim is num_blocks.
+            block_ids: Block IDs to fill. IDs that are out of range for this
+                tensor's first dim are ignored.
+        """
+        # Convert block_ids to tensor on device
+        block_ids_tensor = torch.tensor(
+            block_ids, dtype=torch.long, device=kv_cache.device
+        )
+
+        # Filter invalid block IDs
+        valid_mask = block_ids_tensor < kv_cache.shape[0]
+        valid_block_ids = block_ids_tensor[valid_mask]
+
+        if len(valid_block_ids) == 0:
+            return
+
+        # Create fill values - either constant or random
+        block_shape = kv_cache.shape[1:]
+        if self.fill_std > 0:
+            # Random normal sampling
+            fill_values = torch.normal(
+                mean=self.fill_mean,
+                std=self.fill_std,
+                size=(len(valid_block_ids),) + block_shape,
+                dtype=kv_cache.dtype,
+                device=kv_cache.device,
+            )
+        else:
+            # Constant fill value
+            fill_values = torch.full(
+                (len(valid_block_ids),) + block_shape,
+                self.fill_mean,
+                dtype=kv_cache.dtype,
+                device=kv_cache.device,
+            )
+
+        # Batch fill operation
+        kv_cache[valid_block_ids] = fill_values
+
+    def _fill_state_tensor(self, kv_cache: torch.Tensor):
+        """Fill an entire non-block-indexed state tensor with dummy values.
+
+        Hybrid / linear-attention layers (e.g. Mamba, Kimi Delta Attention)
+        store their per-layer state as tensors with no num_blocks dimension,
+        so the whole tensor is filled with the same constant or random values
+        used for block fills, rather than selected block rows.
+
+        Args:
+            kv_cache: A state tensor to fill in its entirety.
+        """
+        if self.fill_std > 0:
+            kv_cache.normal_(mean=self.fill_mean, std=self.fill_std)
+        else:
+            kv_cache.fill_(self.fill_mean)

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -114,6 +114,7 @@ if TYPE_CHECKING:
     VLLM_DISABLE_PYNCCL: bool = False
     VLLM_USE_OINK_OPS: bool = False
     VLLM_MXFP8_EMULATION_DEQUANT_AT_LOAD: bool = True
+    VLLM_USE_BUDDY_BLOCK_POOL: bool = False
     VLLM_ROCM_USE_AITER: bool = False
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
@@ -1090,6 +1091,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Disabled by default.
     "VLLM_USE_OINK_OPS": lambda: (
         os.getenv("VLLM_USE_OINK_OPS", "False").lower() in ("true", "1")
+    ),
+    # Experimental: back the KV-cache free-block allocator with a power-of-two
+    # buddy allocator that supports variable-size (multi-base-block) chunks,
+    # enabling decoupled hybrid (attention + mamba) paging where groups keep
+    # their native page sizes. Disabled by default.
+    "VLLM_USE_BUDDY_BLOCK_POOL": lambda: (
+        os.getenv("VLLM_USE_BUDDY_BLOCK_POOL", "False").lower() in ("true", "1")
     ),
     # Disable aiter ops unless specifically enabled.
     # Acts as a parent switch to enable the rest of the other operations.

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -538,6 +538,7 @@ class Platform:
         """
         from math import lcm
 
+        from vllm import envs
         from vllm.config.vllm import set_current_vllm_config
         from vllm.model_executor.models import ModelRegistry
         from vllm.utils.math_utils import cdiv
@@ -553,6 +554,13 @@ class Platform:
         cache_config = vllm_config.cache_config
         model_config = vllm_config.model_config
         parallel_config = vllm_config.parallel_config
+
+        # Buddy + decoupled-page mode: skip the uniformization that inflates
+        # attn_block_size up to mamba's native page size. Attn keeps its
+        # kernel-natural block_size so prefix caching can hit at fine
+        # granularity; mamba keeps its native page_size (no padding).
+        # Downstream tensor allocation must handle non-uniform pages.
+        _buddy_decouple = envs.VLLM_USE_BUDDY_BLOCK_POOL
 
         if cache_config.cache_dtype == "auto":
             kv_cache_dtype = model_config.dtype
@@ -627,6 +635,47 @@ class Platform:
         ).page_size_bytes
 
         if mamba_page_size == 0:
+            return
+
+        if _buddy_decouple:
+            # In decoupled mode we let attn and mamba keep their native pages.
+            # We still need cache_config.mamba_block_size set for mamba kernels
+            # (and aligned to chunk_size under mamba_cache_mode='all'), but we
+            # do NOT inflate attn block_size and do NOT pad mamba's page.
+            with set_current_vllm_config(vllm_config):
+                kernel_block_alignment_size = max(
+                    min(
+                        s.base if isinstance(s, MultipleOf) else s
+                        for s in backend_cls.get_supported_kernel_block_sizes()
+                    ),
+                    cache_config.block_size,
+                )
+            if cache_config.mamba_cache_mode == "all":
+                # "all" caches mamba state for every chunk across the
+                # sequence, so mamba_block_size defines the chunk/page
+                # boundaries that MambaSpec.max_memory_usage_bytes later uses
+                # to count pages. Keep those boundaries aligned to the model's
+                # mamba chunk size and to the attention backend's kernel block
+                # alignment, without inflating the attention block_size.
+                base_chunk_size = (
+                    cache_config.mamba_block_size
+                    if cache_config.user_specified_mamba_block_size
+                    else model_config.get_mamba_chunk_size()
+                )
+                assert base_chunk_size is not None
+                cache_config.mamba_block_size = lcm(
+                    base_chunk_size, kernel_block_alignment_size
+                )
+            elif cache_config.mamba_cache_mode == "align":
+                cache_config.mamba_block_size = cache_config.block_size
+            logger.info(
+                "Decoupled hybrid page sizes: attn_block_size=%d, "
+                "mamba_block_size=%d, attn_page=%d B, mamba_native_page=%d B",
+                cache_config.block_size,
+                cache_config.mamba_block_size,
+                cache_config.block_size * attn_page_size_1_token,
+                mamba_page_size,
+            )
             return
 
         # mamba_block_size here should either be user specified value or None

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -12,7 +12,7 @@ from vllm.distributed.kv_events import (
     KVCacheEvent,
 )
 from vllm.logger import init_logger
-from vllm.v1.core.kv_cache_allocator import KVCacheBlockAllocator
+from vllm.v1.core.kv_cache_allocator import BlockAllocator
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
@@ -165,14 +165,10 @@ class BlockPool:
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
         self.num_gpu_blocks = num_gpu_blocks
-        # Experimental: swap the LRU free-queue for a buddy-allocator-backed
-        # one. Prefix caching coexists with buddy mode via an eviction
-        # callback: when the buddy queue splits a cached chunk (alloc walks
-        # up and needs a smaller piece) or coalesces two cached chunks (free
-        # merges siblings into a larger chunk), the affected chunks' hash
-        # entries are dropped from the cache map before the structural
-        # change. Touch/remove already work without a hash op because they
-        # operate on the block whose span is known.
+        # Experimental: swap the LRU free-queue for a buddy allocator that
+        # supports variable-span (multi-base-block) chunks. Either way the
+        # allocator owns its own eviction policy and reclaims cached candidates
+        # internally; BlockPool only calls allocate/free/reuse.
         self._buddy_mode = envs.VLLM_USE_BUDDY_BLOCK_POOL
         self.enable_caching = enable_caching
         self.hash_block_size = hash_block_size
@@ -180,35 +176,40 @@ class BlockPool:
         self.blocks: list[KVCacheBlock] = [
             KVCacheBlock(idx) for idx in range(num_gpu_blocks)
         ]
-        # State the eviction callback reads — set BEFORE the queue is built.
+        # State the eviction hook reads — set BEFORE the allocator is built.
         self.cached_block_hash_to_block: BlockHashToBlockMap = BlockHashToBlockMap()
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue: list[KVCacheEvent] = []
         self.metrics_collector = metrics_collector
-        # Free block queue that constructs and manipulates a doubly linked
-        # list of free blocks (including eviction candidates when caching is
-        # enabled). The allocator is held behind the KVCacheBlockAllocator
-        # interface so the strategy is swappable; nothing outside this pool
-        # needs to know which concrete allocator is in use.
-        self.free_block_queue: KVCacheBlockAllocator
+        # The allocator is held behind the BlockAllocator interface so the
+        # strategy is swappable; nothing outside this pool needs to know which
+        # concrete allocator is in use. The eviction hook drops a reclaimed
+        # block's prefix-cache hash from the map this pool owns.
+        self.allocator: BlockAllocator
         if self._buddy_mode:
-            from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+            from vllm.v1.core.buddy_free_queue import BuddyAllocator
+            from vllm.v1.core.eviction_policy import LRUEvictionPolicy
 
-            # The buddy queue owns the span->order translation; the pool only
-            # forwards the layout-derived max span, so spanned allocations
+            # The buddy allocator owns the span->order translation; the pool
+            # only forwards the layout-derived max span, so spanned allocations
             # always fit with no env tuning.
-            self.free_block_queue = BuddyFreeKVCacheBlockQueue.for_max_span(
+            self.allocator = BuddyAllocator.for_max_span(
                 self.blocks,
                 max_allocation_span,
-                on_evict=self._maybe_evict_cached_block,
+                evictor=LRUEvictionPolicy(on_evict=self._maybe_evict_cached_block),
             )
         else:
-            self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
+            self.allocator = FreeKVCacheBlockQueue(
+                self.blocks, on_evict=self._maybe_evict_cached_block
+            )
+        # Back-compat alias for the few consumers that reach the allocator
+        # directly (e.g. simple_kv_offload walks the default LRU queue).
+        self.free_block_queue = self.allocator
 
         # To represent a placeholder block with block_id=0.
         # The ref_cnt of null_block is not maintained, needs special care to
         # avoid freeing it.
-        self.null_block = self.free_block_queue.popleft()
+        self.null_block = self.allocator.allocate(1)
         self.null_block.is_null = True
 
     def get_cached_block(
@@ -369,55 +370,30 @@ class BlockPool:
         that fit in raw base-block count but cannot be carved at the requested
         spans, so a request cannot pass admission and then fail to allocate.
         """
-        return self.free_block_queue.can_allocate_spans(demand_by_span)
+        return self.allocator.can_allocate(demand_by_span)
 
     def get_new_blocks(self, num_blocks: int, base_span: int = 1) -> list[KVCacheBlock]:
-        """Allocate ``num_blocks`` new logical blocks from the free pool.
+        """Allocate ``num_blocks`` new logical blocks from the allocator.
 
-        Each logical block spans ``base_span`` consecutive base blocks.
-        ``base_span == 1`` (the default) is the ordinary single-base-block path
-        used by the uniform-page layout and by attention groups. A
-        ``base_span > 1`` request (decoupled hybrid mode, e.g. a mamba group)
-        is served as an aligned multi-base-block chunk by the underlying
-        allocator and is all-or-nothing: if the full batch cannot be obtained,
-        any blocks acquired so far are returned and the call raises, leaving the
-        pool's free count and all ref counts unchanged.
+        Each logical block spans ``base_span`` consecutive base blocks
+        (``base_span == 1`` is the ordinary single-base-block path used by the
+        uniform-page layout and by attention groups). The allocator reclaims
+        cached eviction candidates internally when free memory is short and
+        returns memory that never carries a stale hash, so no eviction happens
+        here. Allocation is all-or-nothing: if the full batch cannot be
+        obtained, any blocks acquired so far are returned and the call raises,
+        leaving ref counts unchanged.
 
         Each returned block is identified by its starting base-block id; callers
         that index per-base-id use the start id and reserve the remaining
         ``base_span - 1`` ids. We do not check the prefix cache here.
         """
-        if base_span == 1:
-            if num_blocks > self.get_num_free_blocks():
-                raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
-            ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
-            # In order to only iterate the list once, we duplicated code a bit
-            if self.enable_caching:
-                for block in ret:
-                    self._maybe_evict_cached_block(block)
-                    assert block.ref_cnt == 0
-                    block.ref_cnt += 1
-                    if self.metrics_collector:
-                        self.metrics_collector.on_block_allocated(block)
-            else:
-                for block in ret:
-                    assert block.ref_cnt == 0
-                    block.ref_cnt += 1
-                    if self.metrics_collector:
-                        self.metrics_collector.on_block_allocated(block)
-            return ret
-
-        # Variable-span (base_span > 1) path: allocate aligned chunks
-        # atomically so a mid-batch failure leaves the pool untouched.
-        ret = []
+        if num_blocks * base_span > self.get_num_free_blocks():
+            raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
+        ret: list[KVCacheBlock] = []
         try:
             for _ in range(num_blocks):
-                # The variable-span allocator evicts a reclaimed cached chunk's
-                # hash through the on_evict callback (wired to
-                # _maybe_evict_cached_block) before reusing it, so the returned
-                # block never carries a stale hash and needs no extra eviction
-                # here.
-                block = self.free_block_queue.allocate_spanned_block(base_span)
+                block = self.allocator.allocate(base_span)
                 assert block.ref_cnt == 0
                 block.ref_cnt += 1
                 ret.append(block)
@@ -426,7 +402,7 @@ class BlockPool:
             # whole batch succeeds (below), so there is nothing to reverse.
             for block in ret:
                 block.ref_cnt -= 1
-                self.free_block_queue.free_spanned_block(block)
+                self.allocator.free(block)
             raise
         if self.metrics_collector:
             for block in ret:
@@ -479,10 +455,10 @@ class BlockPool:
             blocks: A list of blocks to touch.
         """
         for block in blocks:
-            # ref_cnt=0 means this block is in the free list (i.e. eviction
-            # candidate), so remove it.
+            # ref_cnt=0 means this block is free (a cached eviction candidate),
+            # so the prefix-cache hit reclaims it from the allocator.
             if block.ref_cnt == 0 and not block.is_null:
-                self.free_block_queue.remove(block)
+                self.allocator.reuse(block)
             block.ref_cnt += 1
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
@@ -503,13 +479,14 @@ class BlockPool:
         blocks_list = list(ordered_blocks)
         for block in blocks_list:
             block.ref_cnt -= 1
-        freed_blocks = [
-            block for block in blocks_list if block.ref_cnt == 0 and not block.is_null
-        ]
-        if prepend:
-            self.free_block_queue.prepend_n(freed_blocks)
-        else:
-            self.free_block_queue.append_n(freed_blocks)
+        freed = [b for b in blocks_list if b.ref_cnt == 0 and not b.is_null]
+        # The allocator routes each freed block: a still-cached block becomes a
+        # reclaim candidate, an uncached block returns to truly-free memory.
+        # ``prepend`` prioritises the blocks for the next allocation; free in
+        # reverse so the batch ends up in ``freed`` order at the reuse-soon end
+        # (matching the old prepend_n/append_n batch semantics).
+        for block in reversed(freed) if prepend else freed:
+            self.allocator.free(block, prefer_reuse=prepend)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.
@@ -571,7 +548,7 @@ class BlockPool:
         Returns:
             The number of free blocks.
         """
-        return self.free_block_queue.num_free_blocks
+        return self.allocator.num_free_blocks
 
     def get_usage(self) -> float:
         """Get the KV cache usage.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable, Sequence
 from typing import Any
 
+import vllm.envs as envs
 from vllm.distributed.kv_events import (
     MEDIUM_GPU,
     AllBlocksCleared,
@@ -11,6 +12,7 @@ from vllm.distributed.kv_events import (
     KVCacheEvent,
 )
 from vllm.logger import init_logger
+from vllm.v1.core.kv_cache_allocator import KVCacheBlockAllocator
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
@@ -144,6 +146,12 @@ class BlockPool:
             actual block size can be a multiple of hash_block_size.
         enable_kv_cache_events: Whether to enable kv cache events.
         metrics_collector: Optional metrics collector for tracking block residency.
+        max_allocation_span: Largest per-logical-block allocation span (in base
+            blocks) any group will request, derived by the caller from the
+            layout's per-group ``allocation_base_span``. Allocator-neutral: a
+            span-1-only allocator ignores it; a variable-span allocator sizes
+            itself to support spans up to this value. Defaults to 1 (single
+            base block per logical block).
     """
 
     def __init__(
@@ -153,33 +161,55 @@ class BlockPool:
         hash_block_size: int,
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        max_allocation_span: int = 1,
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
         self.num_gpu_blocks = num_gpu_blocks
+        # Experimental: swap the LRU free-queue for a buddy-allocator-backed
+        # one. Prefix caching coexists with buddy mode via an eviction
+        # callback: when the buddy queue splits a cached chunk (alloc walks
+        # up and needs a smaller piece) or coalesces two cached chunks (free
+        # merges siblings into a larger chunk), the affected chunks' hash
+        # entries are dropped from the cache map before the structural
+        # change. Touch/remove already work without a hash op because they
+        # operate on the block whose span is known.
+        self._buddy_mode = envs.VLLM_USE_BUDDY_BLOCK_POOL
         self.enable_caching = enable_caching
         self.hash_block_size = hash_block_size
         # All kv-cache blocks.
         self.blocks: list[KVCacheBlock] = [
             KVCacheBlock(idx) for idx in range(num_gpu_blocks)
         ]
+        # State the eviction callback reads — set BEFORE the queue is built.
+        self.cached_block_hash_to_block: BlockHashToBlockMap = BlockHashToBlockMap()
+        self.enable_kv_cache_events = enable_kv_cache_events
+        self.kv_event_queue: list[KVCacheEvent] = []
+        self.metrics_collector = metrics_collector
         # Free block queue that constructs and manipulates a doubly linked
         # list of free blocks (including eviction candidates when caching is
-        # enabled).
-        self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
+        # enabled). The allocator is held behind the KVCacheBlockAllocator
+        # interface so the strategy is swappable; nothing outside this pool
+        # needs to know which concrete allocator is in use.
+        self.free_block_queue: KVCacheBlockAllocator
+        if self._buddy_mode:
+            from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
 
-        # Cache for block lookup
-        self.cached_block_hash_to_block: BlockHashToBlockMap = BlockHashToBlockMap()
+            # The buddy queue owns the span->order translation; the pool only
+            # forwards the layout-derived max span, so spanned allocations
+            # always fit with no env tuning.
+            self.free_block_queue = BuddyFreeKVCacheBlockQueue.for_max_span(
+                self.blocks,
+                max_allocation_span,
+                on_evict=self._maybe_evict_cached_block,
+            )
+        else:
+            self.free_block_queue = FreeKVCacheBlockQueue(self.blocks)
 
         # To represent a placeholder block with block_id=0.
         # The ref_cnt of null_block is not maintained, needs special care to
         # avoid freeing it.
         self.null_block = self.free_block_queue.popleft()
         self.null_block.is_null = True
-
-        self.enable_kv_cache_events = enable_kv_cache_events
-        self.kv_event_queue: list[KVCacheEvent] = []
-
-        self.metrics_collector = metrics_collector
 
     def get_cached_block(
         self, block_hash: BlockHash, kv_cache_group_ids: list[int]
@@ -330,36 +360,77 @@ class BlockPool:
                 )
             )
 
-    def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
-        """Get new blocks from the free block pool.
+    def can_allocate_demands(self, demand_by_span: dict[int, int]) -> bool:
+        """Whether the allocator can satisfy a joint ``{base_span: num_blocks}``
+        demand, accounting for any alignment/fragmentation it imposes.
 
-        Note that we do not check block cache in this function.
-
-        Args:
-            num_blocks: The number of blocks to allocate.
-
-        Returns:
-            A list of new block.
+        The uniform LRU allocator supports only span 1 and gates on the raw
+        free count; the variable-span allocator additionally rejects demands
+        that fit in raw base-block count but cannot be carved at the requested
+        spans, so a request cannot pass admission and then fail to allocate.
         """
-        if num_blocks > self.get_num_free_blocks():
-            raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
+        return self.free_block_queue.can_allocate_spans(demand_by_span)
 
-        ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+    def get_new_blocks(self, num_blocks: int, base_span: int = 1) -> list[KVCacheBlock]:
+        """Allocate ``num_blocks`` new logical blocks from the free pool.
 
-        # In order to only iterate the list once, we duplicated code a bit
-        if self.enable_caching:
-            for block in ret:
-                self._maybe_evict_cached_block(block)
+        Each logical block spans ``base_span`` consecutive base blocks.
+        ``base_span == 1`` (the default) is the ordinary single-base-block path
+        used by the uniform-page layout and by attention groups. A
+        ``base_span > 1`` request (decoupled hybrid mode, e.g. a mamba group)
+        is served as an aligned multi-base-block chunk by the underlying
+        allocator and is all-or-nothing: if the full batch cannot be obtained,
+        any blocks acquired so far are returned and the call raises, leaving the
+        pool's free count and all ref counts unchanged.
+
+        Each returned block is identified by its starting base-block id; callers
+        that index per-base-id use the start id and reserve the remaining
+        ``base_span - 1`` ids. We do not check the prefix cache here.
+        """
+        if base_span == 1:
+            if num_blocks > self.get_num_free_blocks():
+                raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
+            ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+            # In order to only iterate the list once, we duplicated code a bit
+            if self.enable_caching:
+                for block in ret:
+                    self._maybe_evict_cached_block(block)
+                    assert block.ref_cnt == 0
+                    block.ref_cnt += 1
+                    if self.metrics_collector:
+                        self.metrics_collector.on_block_allocated(block)
+            else:
+                for block in ret:
+                    assert block.ref_cnt == 0
+                    block.ref_cnt += 1
+                    if self.metrics_collector:
+                        self.metrics_collector.on_block_allocated(block)
+            return ret
+
+        # Variable-span (base_span > 1) path: allocate aligned chunks
+        # atomically so a mid-batch failure leaves the pool untouched.
+        ret = []
+        try:
+            for _ in range(num_blocks):
+                # The variable-span allocator evicts a reclaimed cached chunk's
+                # hash through the on_evict callback (wired to
+                # _maybe_evict_cached_block) before reusing it, so the returned
+                # block never carries a stale hash and needs no extra eviction
+                # here.
+                block = self.free_block_queue.allocate_spanned_block(base_span)
                 assert block.ref_cnt == 0
                 block.ref_cnt += 1
-                if self.metrics_collector:
-                    self.metrics_collector.on_block_allocated(block)
-        else:
+                ret.append(block)
+        except Exception:
+            # All-or-nothing rollback. Metrics are recorded only after the
+            # whole batch succeeds (below), so there is nothing to reverse.
             for block in ret:
-                assert block.ref_cnt == 0
-                block.ref_cnt += 1
-                if self.metrics_collector:
-                    self.metrics_collector.on_block_allocated(block)
+                block.ref_cnt -= 1
+                self.free_block_queue.free_spanned_block(block)
+            raise
+        if self.metrics_collector:
+            for block in ret:
+                self.metrics_collector.on_block_allocated(block)
         return ret
 
     def _maybe_evict_cached_block(self, block: KVCacheBlock) -> bool:

--- a/vllm/v1/core/buddy_free_queue.py
+++ b/vllm/v1/core/buddy_free_queue.py
@@ -1,49 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Per-order LRU buddy-backed free queue.
+"""Power-of-two buddy allocator for variable-span KV-cache blocks.
 
-Drop-in replacement for ``FreeKVCacheBlockQueue`` when variable-size
-allocations are needed. Differences vs. the LRU queue:
+A ``BlockAllocator`` (see ``kv_cache_allocator.py``) that hands out aligned
+chunks of ``2**order`` base blocks. Used when groups need different page sizes
+(decoupled hybrid paging); the default span-1 path uses the LRU
+``FreeKVCacheBlockQueue`` instead.
 
-- Free blocks are organised as one doubly-linked LRU list **per buddy order**.
-  Each list threads through the ``prev_free_block`` / ``next_free_block``
-  attributes of ``KVCacheBlock`` (same pointer slots the LRU queue uses, so a
-  block lives in at most one queue at a time).
-- ``alloc_chunk(order)`` pops the LRU head of that order's list; if empty it
-  walks up, pops a larger chunk, and splits — pushing the buddy half(ves)
-  back into lower-order LRU tails. Returns the head block with
-  ``base_span = 2**order`` recorded on it.
-- ``append(block)`` reads ``block.base_span``, attempts eager coalesce with
-  its buddy if the buddy is also free at the same order, otherwise links the
-  block into the appropriate order's LRU tail.
-- ``remove(block)`` reads ``block.base_span`` and unlinks the block from
-  its LRU in O(1) — no order parameter, same signature as the LRU queue's
-  ``remove``. The chunk leaves the free pool entirely; the caller is
-  responsible for tracking it.
-- ``popleft()`` and ``popleft_n()`` delegate to ``alloc_chunk(order=0)``.
+Reclaim model: this allocator's free structure only ever holds *truly-free*
+memory. Cached-but-reusable blocks live in an ``EvictionPolicy`` the allocator
+*owns* (``self._evictor``). When ``allocate`` can't satisfy a request from free
+memory it reclaims the policy's least-recently-used candidate (dropping its
+hash via the policy's ``on_evict`` hook), frees that memory back to itself —
+which eagerly coalesces — and retries. Because the free structure never holds
+cached chunks, there is no preserve-cached special case and coalescing is
+always unconditional.
 
-The structure preserves the buddy invariant that a free chunk at order ``k``
-starts at an id that is a multiple of ``2**k``, but storage is now per-order
-LRU rather than per-order sets.
-
-Prefix-cache fragmentation policy (preserve-cached): a cached chunk (one whose
-``block_hash`` is set) is preserved, not merged away. ``append`` refuses to
-coalesce two buddies if either side holds a cache hash, so a cached chunk keeps
-its identity and can still serve a prefix-cache hit. A cached chunk only loses
-its hash when an allocation must reclaim its memory — either it is popped to
-satisfy a same-order request after all uncached chunks are exhausted, or it is
-split to satisfy a smaller request. In both cases ``on_evict`` fires *before*
-the structural change so the prefix-cache hash map never retains a stale entry,
-and memory reused by a new request never carries a previous owner's hash. The
-cost of preserving cached chunks is potential fragmentation under cache
-pressure; that is a throughput trade-off, not a correctness issue — allocation
-remains correct because it falls back to evicting cached chunks when needed.
+Free chunks are organised as one doubly-linked list per order, threaded through
+the ``prev_free_block`` / ``next_free_block`` slots of ``KVCacheBlock`` (the same
+slots the LRU queue and the eviction policy use; a block lives in exactly one of
+them at a time). A per-order set of free chunk start-ids backs O(1) buddy-
+membership tests during coalesce — pointer presence alone cannot distinguish a
+pool-free block from one held by the eviction policy, since both use the same
+link slots.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Sequence
 
+from vllm.v1.core.eviction_policy import LRUEvictionPolicy
+from vllm.v1.core.kv_cache_allocator import EvictionPolicy
 from vllm.v1.core.kv_cache_utils import KVCacheBlock
 
 
@@ -52,27 +39,21 @@ def _make_sentinel(block_id: int = -1) -> KVCacheBlock:
     return KVCacheBlock(block_id=block_id)
 
 
-class BuddyFreeKVCacheBlockQueue:
+class BuddyAllocator:
     def __init__(
         self,
         blocks: list[KVCacheBlock],
         max_order: int = 0,
-        on_evict: Callable[[KVCacheBlock], bool] | None = None,
+        evictor: EvictionPolicy | None = None,
     ) -> None:
         """Args:
         blocks: One ``KVCacheBlock`` per base-block id, ordered by id.
         max_order: Largest buddy order. ``2**max_order`` need not divide
-            ``len(blocks)``; any tail ids beyond the largest aligned
-            prefix are added as order-0 chunks (cannot coalesce up).
-        on_evict: Optional callback fired before a cached chunk loses
-            its identity due to a split (in ``alloc_chunk``) or a
-            coalesce (in ``append``). The callback should drop the
-            block's hash from the prefix-cache map and call
-            ``block.reset_hash()``. Signature mirrors
-            ``BlockPool._maybe_evict_cached_block``: returns True if
-            anything was evicted; the return value is ignored here.
-            When ``None`` (default), no eviction is performed — only
-            safe when prefix caching is disabled at the pool level.
+            ``len(blocks)``; any tail ids beyond the largest aligned prefix are
+            served only as order-0 chunks (they cannot coalesce up).
+        evictor: The eviction policy holding cached reclaim candidates. When
+            ``None`` (prefix caching disabled), a no-op policy is used —
+            nothing is ever tracked, so ``allocate`` never reclaims.
         """
         if max_order < 0:
             raise ValueError(f"max_order must be non-negative, got {max_order}")
@@ -80,11 +61,13 @@ class BuddyFreeKVCacheBlockQueue:
         if n == 0:
             raise ValueError("blocks must be non-empty")
         self._max_order = max_order
-        self._on_evict = on_evict
+        self._evictor: EvictionPolicy = (
+            evictor if evictor is not None else LRUEvictionPolicy(on_evict=None)
+        )
         self._blocks_by_id: dict[int, KVCacheBlock] = {b.block_id: b for b in blocks}
 
-        # Per-order LRU: heads[k] -> ... -> tails[k]. Lowest id at head end
-        # initially; subsequent appends go to the tail (= MRU end).
+        # Per-order free list (head -> ... -> tail) plus a per-order set of free
+        # chunk start-ids for O(1) buddy-membership checks.
         self._heads: list[KVCacheBlock] = [
             _make_sentinel() for _ in range(max_order + 1)
         ]
@@ -94,21 +77,12 @@ class BuddyFreeKVCacheBlockQueue:
         for k in range(max_order + 1):
             self._heads[k].next_free_block = self._tails[k]
             self._tails[k].prev_free_block = self._heads[k]
+        self._pool_starts: list[set[int]] = [set() for _ in range(max_order + 1)]
+        self._pool_free: int = 0
 
-        # Seed the largest aligned prefix as max-order chunks. Any tail ids
-        # (not a multiple of 2**max_order from 0) live in a side fallback
-        # list, NOT in the order-0 LRU. Two reasons:
-        # 1. ``NULL_BLOCK_ID = 0`` is hardcoded in the attention/mamba
-        #    kernels — they assume the first popleft() (which becomes
-        #    BlockPool.null_block) returns id 0. Keeping order-0 LRU empty
-        #    at init means popleft must walk up to max_order, where the
-        #    LRU head is block 0, and splits down through the low halves
-        #    to return block 0.
-        # 2. Tail blocks can't form valid buddy chunks (their buddies
-        #    would be out-of-range), so eager coalesce would waste cycles
-        #    checking buddies that don't exist. Keeping them in a side
-        #    list lets popleft drain the aligned pool first and only fall
-        #    back to tail blocks under pressure.
+        # Seed the largest aligned prefix as max-order chunks. Tail ids (not a
+        # multiple of 2**max_order from 0) can't form valid buddy chunks, so
+        # they live in a side fallback list served only for order-0 requests.
         chunk = 1 << max_order
         aligned_n = (n // chunk) * chunk
         if aligned_n == 0:
@@ -116,367 +90,222 @@ class BuddyFreeKVCacheBlockQueue:
                 f"len(blocks)={n} too small for max_order={max_order} "
                 f"(need at least {chunk})"
             )
-        # ``_link_tail`` puts uncached blocks at the LRU HEAD (so they pop
-        # first), which means each insert pushes earlier inserts back. Seed
-        # in REVERSE id order so that block 0 ends up at the head — this
-        # preserves the NULL_BLOCK_ID = 0 invariant: the very first popleft
-        # (which BlockPool consumes as the null block) returns id 0.
+        # ``_pool_add`` links at the HEAD, so each insert pushes earlier inserts
+        # back. Seed in REVERSE id order so block 0 ends up at the head: the
+        # very first allocate(1) (which BlockPool consumes as the null block)
+        # walks up to max_order, pops block 0's chunk, and splits down to
+        # return id 0 — preserving the hardcoded NULL_BLOCK_ID = 0 invariant.
         for start in range(aligned_n - chunk, -1, -chunk):
             head = blocks[start]
             head.base_span = 1 << max_order
-            self._link_tail(head, max_order)
-        # Tail blocks: pop from the end (LIFO) so iterating popleft sees
-        # higher ids first, matching the LRU-queue convention that initial
-        # block order is by id.
+            self._pool_add(head, max_order)
         self._tail_free: list[int] = list(range(aligned_n, n))
         self._tail_allocated: set[int] = set()
 
-        self.num_free_blocks: int = n
-
-    # ----------------------- LRU linked-list helpers ------------------------
-    def _link_tail(self, block: KVCacheBlock, order: int) -> None:
-        """Insert ``block`` at the MRU end of order ``order``.
-
-        Cached blocks (``block_hash is not None``) go to the TAIL — they age
-        out via LRU and are evicted last. Uncached blocks go to the HEAD so
-        they are popped first, preserving cached chunks. Combined with the
-        coalesce-skip rule in ``append``, this means the order-K LRU layout
-        is: ``[uncached newest → ... → uncached oldest][cached oldest → ...
-        → cached newest]``. The head's hash state tells us in O(1) whether
-        any uncached chunk exists at this order — used by ``alloc_chunk``
-        to prefer splitting a higher-order uncached chunk over evicting a
-        same-order cached one.
-        """
-        if block.block_hash is None:
-            # Uncached: link at HEAD so it pops first.
-            head = self._heads[order]
-            nxt = head.next_free_block
-            assert nxt is not None
-            head.next_free_block = block
-            block.prev_free_block = head
-            block.next_free_block = nxt
-            nxt.prev_free_block = block
-        else:
-            # Cached: link at TAIL (MRU end) for LRU eviction.
-            tail = self._tails[order]
-            prev = tail.prev_free_block
-            assert prev is not None
-            prev.next_free_block = block
-            block.prev_free_block = prev
-            block.next_free_block = tail
-            tail.prev_free_block = block
+    # --------------------------- pool helpers -------------------------------
+    def _pool_add(self, block: KVCacheBlock, order: int) -> None:
+        """Link ``block`` at the head of order ``order`` and mark it free."""
+        head = self._heads[order]
+        nxt = head.next_free_block
+        assert nxt is not None
+        head.next_free_block = block
+        block.prev_free_block = head
+        block.next_free_block = nxt
+        nxt.prev_free_block = block
+        self._pool_starts[order].add(block.block_id)
+        self._pool_free += 1 << order
 
     def _unlink(self, block: KVCacheBlock) -> None:
-        """Unlink ``block`` from whatever per-order LRU it's currently in."""
         prev = block.prev_free_block
         nxt = block.next_free_block
-        if prev is None or nxt is None:
-            raise RuntimeError(f"_unlink called on block not in any LRU: {block}")
+        assert prev is not None and nxt is not None
         prev.next_free_block = nxt
         nxt.prev_free_block = prev
         block.prev_free_block = None
         block.next_free_block = None
 
-    def _pop_head(self, order: int) -> KVCacheBlock | None:
-        """Pop the LRU head of order ``order``, or None if empty."""
+    def _pool_remove(self, block: KVCacheBlock, order: int) -> None:
+        """Take ``block`` out of order ``order``'s free list."""
+        self._unlink(block)
+        self._pool_starts[order].discard(block.block_id)
+        self._pool_free -= 1 << order
+
+    def _pool_pop_head(self, order: int) -> KVCacheBlock | None:
         head = self._heads[order]
         first = head.next_free_block
         assert first is not None
         if first is self._tails[order]:
             return None
-        self._unlink(first)
+        self._pool_remove(first, order)
         return first
 
-    def _is_in_queue(self, block: KVCacheBlock) -> bool:
-        return block.prev_free_block is not None and block.next_free_block is not None
+    def _smallest_available_order(self, order: int) -> int | None:
+        for k in range(order, self._max_order + 1):
+            if self._pool_starts[k]:
+                return k
+        return None
 
-    # --------------------------- public surface -----------------------------
+    @staticmethod
+    def _span_to_order(span: int) -> int:
+        order = span.bit_length() - 1
+        if span < 1 or (1 << order) != span:
+            raise ValueError(f"span must be a power of two, got {span}")
+        return order
+
+    # --------------------------- BlockAllocator -----------------------------
     @property
     def max_order(self) -> int:
         return self._max_order
 
-    def popleft(self) -> KVCacheBlock:
-        """Single base-block alloc (= alloc_chunk(0))."""
-        return self.alloc_chunk(order=0)
+    @property
+    def num_free_blocks(self) -> int:
+        """Base blocks available: free pool plus reclaimable candidates."""
+        return self._pool_free + self._evictor.num_reclaimable
 
-    def popleft_n(self, n: int) -> list[KVCacheBlock]:
-        if n == 0:
-            return []
-        if n > self.num_free_blocks:
-            raise ValueError(
-                f"Cannot pop {n} blocks (only {self.num_free_blocks} free)"
-            )
-        return [self.alloc_chunk(order=0) for _ in range(n)]
+    def allocate(self, span: int = 1) -> KVCacheBlock:
+        """Allocate one chunk of ``span`` (a power-of-two count of) base blocks.
 
-    def alloc_chunk(self, order: int) -> KVCacheBlock:
-        """Allocate a chunk of ``2**order`` base blocks.
-
-        Returns the head ``KVCacheBlock`` of the chunk (start id), with
-        ``base_span = 2**order`` set on it.
+        Returns the head ``KVCacheBlock`` of the chunk with ``base_span`` set.
+        Reclaims LRU eviction candidates when free memory is short.
         """
-        if order < 0 or order > self._max_order:
-            raise ValueError(f"order {order} out of range [0, {self._max_order}]")
-        # Pass 1: prefer an UNCACHED chunk to avoid evicting a cached one.
-        # Because _link_tail puts uncached blocks at the HEAD of each order's
-        # LRU, checking the head's hash is an O(1) test for "any uncached
-        # chunk available at this order". We walk up looking for the smallest
-        # order whose head is uncached.
-        src = order
-        while src <= self._max_order:
-            head = self._heads[src].next_free_block
-            if head is not self._tails[src] and head.block_hash is None:
+        order = self._span_to_order(span)
+        if order > self._max_order:
+            raise ValueError(f"span {span} exceeds max order {self._max_order}")
+        while True:
+            src = self._smallest_available_order(order)
+            if src is not None:
                 break
-            src += 1
-        if src > self._max_order:
-            # Pass 2: no uncached chunk anywhere. Fall back to evicting the
-            # LRU-head cached chunk at the smallest non-empty order.
-            src = order
-            while src <= self._max_order:
-                if self._heads[src].next_free_block is not self._tails[src]:
-                    break
-                src += 1
-        if src > self._max_order:
-            # Fall back to tail blocks for order-0 requests only — tail
-            # ids aren't aligned for higher orders.
+            # Unaligned tail ids can serve order-0 requests only.
             if order == 0 and self._tail_free:
                 bid = self._tail_free.pop()
                 self._tail_allocated.add(bid)
-                self.num_free_blocks -= 1
+                self._pool_free -= 1
                 blk = self._blocks_by_id[bid]
                 blk.base_span = 1
                 return blk
-            raise ValueError(f"No free chunk of order >= {order} available")
-        block = self._pop_head(src)
+            # Reclaim a cached candidate and retry; the freed memory coalesces.
+            victim = self._evictor.pop_victim()
+            if victim is None:
+                raise ValueError(f"No free chunk of order >= {order} available")
+            self._free_to_pool(victim)
+        block = self._pool_pop_head(src)
         assert block is not None
-        # If the popped chunk is cached, drop its hash before reusing the
-        # memory. This covers both same-order eviction (src == order, no
-        # uncached found) and the older split-on-cached case (src > order
-        # — should be rare with the uncached-first pass but possible if a
-        # higher-order chunk got cached somehow).
-        if self._on_evict is not None and block.block_hash is not None:
-            self._on_evict(block)
-        # Split src -> order: at each level, the high-half buddy goes into
-        # its order's LRU tail; the low half continues down.
+        # Split src -> order: high-half buddies go back to their order's list.
         while src > order:
             src -= 1
-            buddy_id = block.block_id + (1 << src)
-            buddy = self._blocks_by_id[buddy_id]
+            buddy = self._blocks_by_id[block.block_id + (1 << src)]
             buddy.base_span = 1 << src
-            self._link_tail(buddy, src)
+            self._pool_add(buddy, src)
         block.base_span = 1 << order
-        self.num_free_blocks -= 1 << order
         return block
 
-    def can_allocate_chunks(self, order: int, num_chunks: int) -> bool:
-        """Whether ``num_chunks`` chunks of ``2**order`` base blocks can be
-        carved from the current free structure.
+    def free(self, block: KVCacheBlock, *, prefer_reuse: bool = False) -> None:
+        """Return ``block`` to the allocator. A cached block becomes a reclaim
+        candidate in the eviction policy; an uncached block returns to the free
+        pool (and eagerly coalesces)."""
+        if block.block_hash is not None:
+            self._evictor.track(block, prefer_reuse=prefer_reuse)
+        else:
+            self._free_to_pool(block)
 
-        A free chunk at order ``j >= order`` can be split into
-        ``2**(j-order)`` chunks of ``order``, so the achievable count is the
-        sum of those contributions across all orders ``>= order`` (plus the
-        unaligned tail-fallback ids for ``order == 0``). Admission uses this so
-        a request that fits in raw base-block count but cannot be satisfied due
-        to buddy alignment/fragmentation is rejected up front rather than
-        failing mid-allocation. This counts structural capacity; cached chunks
-        are included because allocation evicts them when needed.
-        """
-        if num_chunks <= 0:
-            return True
+    def reuse(self, block: KVCacheBlock) -> None:
+        """Prefix-cache hit: pull a cached candidate back out of the policy."""
+        self._evictor.untrack(block)
+
+    def _free_to_pool(self, block: KVCacheBlock) -> None:
+        """Return a chunk to the free pool, coalescing with free buddies up to
+        ``max_order``."""
+        bid = block.block_id
+        if bid in self._tail_allocated:
+            self._tail_allocated.discard(bid)
+            self._tail_free.append(bid)
+            self._pool_free += 1
+            return
+        order = block.base_span.bit_length() - 1
         if order < 0 or order > self._max_order:
-            return False
-        capacity = 0
-        for j in range(order, self._max_order + 1):
-            count = 0
-            cur = self._heads[j].next_free_block
-            tail = self._tails[j]
-            while cur is not None and cur is not tail:
-                count += 1
-                cur = cur.next_free_block
-            capacity += count << (j - order)
-            if capacity >= num_chunks:
-                return True
-        if order == 0:
-            capacity += len(self._tail_free)
-        return capacity >= num_chunks
+            raise ValueError(
+                f"free: base_span {block.base_span} (order {order}) out of "
+                f"range [0, {self._max_order}] for block {block.block_id}"
+            )
+        while order < self._max_order:
+            buddy_id = bid ^ (1 << order)
+            if buddy_id not in self._pool_starts[order]:
+                break
+            self._pool_remove(self._blocks_by_id[buddy_id], order)
+            bid = min(bid, buddy_id)
+            order += 1
+        merged = self._blocks_by_id[bid]
+        merged.base_span = 1 << order
+        self._pool_add(merged, order)
 
-    def can_allocate_demands(self, demand: dict[int, int]) -> bool:
-        """Whether a joint demand of ``{order: num_chunks}`` can be satisfied
-        from the current (eagerly-coalesced) free structure.
+    def can_allocate(self, demand_by_span: dict[int, int]) -> bool:
+        """Whether a joint ``{span: num_blocks}`` demand is satisfiable from the
+        free pool plus reclaimable candidates.
 
-        Allocations from the shared pool compete: carving high-order chunks
-        removes base blocks that lower orders could otherwise use. For a buddy
-        system whose free chunks are maximally coalesced, a multiset of
-        power-of-two requests is satisfiable iff, for every order threshold
-        ``k``, the base blocks demanded by orders ``>= k`` do not exceed the
-        base blocks held in free chunks of order ``>= k`` (a majorization
-        condition). The ``k == 0`` case reduces to the plain base-block count.
-        Unaligned tail-fallback ids only help order 0.
+        A free chunk of order ``j >= k`` contributes its base blocks to every
+        threshold ``k``; a power-of-two demand multiset is satisfiable iff for
+        every threshold ``k`` the base blocks demanded by orders ``>= k`` do not
+        exceed those available in chunks of order ``>= k`` (a majorization
+        condition). Candidates are counted at their stored order without
+        simulating the coalescing reclaim would trigger — this matches the
+        legacy buddy's behavior (which never coalesced cached chunks) and is
+        sound, since reclaim+coalesce can only do better than the check
+        promises. Unaligned tail-fallback ids only help order 0.
         """
-        if not demand:
+        demand_by_order: dict[int, int] = {}
+        for span, count in demand_by_span.items():
+            if count <= 0:
+                continue
+            order = span.bit_length() - 1
+            if span < 1 or (1 << order) != span:
+                return False
+            if order > self._max_order:
+                return False
+            demand_by_order[order] = demand_by_order.get(order, 0) + count
+        if not demand_by_order:
             return True
-        free_chunks_per_order = [0] * (self._max_order + 1)
-        for k in range(self._max_order + 1):
-            count = 0
-            cur = self._heads[k].next_free_block
-            tail = self._tails[k]
-            while cur is not None and cur is not tail:
-                count += 1
-                cur = cur.next_free_block
-            free_chunks_per_order[k] = count
+
+        free_counts = [len(self._pool_starts[k]) for k in range(self._max_order + 1)]
+        for blk in self._evictor.reclaimable_chunks():
+            o = blk.base_span.bit_length() - 1
+            if 0 <= o <= self._max_order:
+                free_counts[o] += 1
         tail_free = len(self._tail_free)
 
         for k in range(self._max_order + 1):
-            demand_base = 0
-            for order, num_chunks in demand.items():
-                if num_chunks <= 0:
-                    continue
-                if order < 0 or order > self._max_order:
-                    return False
-                if order >= k:
-                    demand_base += num_chunks << order
-            free_base = sum(
-                free_chunks_per_order[j] << j for j in range(k, self._max_order + 1)
-            )
+            demand_base = sum(c << o for o, c in demand_by_order.items() if o >= k)
+            free_base = sum(free_counts[j] << j for j in range(k, self._max_order + 1))
             if k == 0:
                 free_base += tail_free
             if demand_base > free_base:
                 return False
         return True
 
-    # ------------------- allocator-neutral interface ------------------------
+    @staticmethod
+    def normalize_span(natural_span: int) -> int:
+        """Round a natural span up to the next power of two — the only spans
+        this buddy allocator can carve and align. ``normalize_span(3) == 4``,
+        ``normalize_span(4) == 4``, ``normalize_span(1) == 1``."""
+        if natural_span <= 1:
+            return 1
+        return 1 << (natural_span - 1).bit_length()
+
     @classmethod
     def for_max_span(
         cls,
         blocks: list[KVCacheBlock],
         max_allocation_span: int,
-        on_evict: Callable[[KVCacheBlock], bool] | None = None,
-    ) -> BuddyFreeKVCacheBlockQueue:
-        """Construct from a neutral max *span* (base blocks per logical block)
-        rather than a buddy order, translating span->order internally. Lets the
-        allocator-agnostic pool size the buddy without speaking "order"."""
+        evictor: EvictionPolicy | None = None,
+    ) -> BuddyAllocator:
+        """Construct from a neutral max *span* (base blocks per logical block),
+        translating span->order internally."""
         max_order = (max(1, max_allocation_span) - 1).bit_length()
-        return cls(blocks, max_order=max_order, on_evict=on_evict)
+        return cls(blocks, max_order=max_order, evictor=evictor)
 
-    @staticmethod
-    def normalize_span(natural_span: int) -> int:
-        """Round a natural span up to the next power of two — the only spans
-        this buddy allocator can carve and align. ``normalize_span(3) == 4``,
-        ``normalize_span(4) == 4``, ``normalize_span(1) == 1``. This is the
-        single home of the power-of-two rounding the layout used to inline."""
-        if natural_span <= 1:
-            return 1
-        return 1 << (natural_span - 1).bit_length()
-
-    @staticmethod
-    def _span_to_order(base_span: int) -> int:
-        order = base_span.bit_length() - 1
-        if base_span < 1 or (1 << order) != base_span:
-            raise ValueError(f"base_span must be a power of two, got {base_span}")
-        return order
-
-    def allocate_spanned_block(self, base_span: int) -> KVCacheBlock:
-        """Allocate one logical block spanning ``base_span`` base blocks."""
-        return self.alloc_chunk(self._span_to_order(base_span))
-
-    def free_spanned_block(self, block: KVCacheBlock) -> None:
-        """Return a spanned block to the pool (span read from ``base_span``)."""
-        self.append(block)
-
-    def can_allocate_spans(self, demand_by_span: dict[int, int]) -> bool:
-        """Whether a ``{base_span: num_blocks}`` demand is satisfiable."""
-        demand_by_order: dict[int, int] = {}
-        for base_span, count in demand_by_span.items():
-            if count <= 0:
-                continue
-            order = base_span.bit_length() - 1
-            if base_span < 1 or (1 << order) != base_span:
-                return False
-            demand_by_order[order] = demand_by_order.get(order, 0) + count
-        return self.can_allocate_demands(demand_by_order)
-
-    def free_chunk(self, start_id: int) -> None:
-        """Back-compat: locate the block by id and call ``append`` on it.
-
-        Callers that hold a ``KVCacheBlock`` should prefer ``append(block)``.
-        """
-        self.append(self._blocks_by_id[start_id])
-
-    def remove(self, block: KVCacheBlock) -> None:
-        """Remove ``block`` (a free-chunk head) from its order's LRU.
-
-        Decrements ``num_free_blocks`` by ``block.base_span``. The caller takes
-        ownership of the chunk; ``append(block)`` returns it.
-        """
-        if not self._is_in_queue(block):
-            raise RuntimeError(f"remove called on block not in any LRU: {block}")
-        self._unlink(block)
-        self.num_free_blocks -= block.base_span
-
-    def append(self, block: KVCacheBlock) -> None:
-        """Return ``block`` (head of a chunk of ``block.base_span`` base
-        blocks) to the free pool. Eagerly coalesces with its buddy if also free
-        at the same order, recursively up to ``max_order``."""
-        bid = block.block_id
-        # Tail-block fast path: not part of the buddy address space, just
-        # return to the side fallback list.
-        if bid in self._tail_allocated:
-            self._tail_allocated.discard(bid)
-            self._tail_free.append(bid)
-            self.num_free_blocks += 1
-            return
-        order = block.base_span.bit_length() - 1
-        if order < 0 or order > self._max_order:
-            raise ValueError(
-                f"append: base_span {block.base_span} (order {order}) out of "
-                f"range [0, {self._max_order}] for block {block.block_id}"
-            )
-        # Coalesce as far up as buddies are free.
-        size_returned = 1 << order
-        while order < self._max_order:
-            buddy_id = bid ^ (1 << order)
-            # Tail-region order-0 ids may have no buddy in the pool.
-            buddy = self._blocks_by_id.get(buddy_id)
-            if buddy is None:
-                break
-            if not self._is_in_queue(buddy) or buddy.base_span != (1 << order):
-                break
-            # Preserve cached identity: if either contributor holds a cache
-            # hash, coalescing would discard a valid prefix-cache entry. Stop
-            # and leave both in their order's LRU. They can still be reused
-            # individually; coalescing resumes once both sides are uncached.
-            cur = self._blocks_by_id[bid]
-            if self._on_evict is not None and (
-                cur.block_hash is not None or buddy.block_hash is not None
-            ):
-                break
-            self._unlink(buddy)
-            bid = min(bid, buddy_id)
-            order += 1
-        merged = self._blocks_by_id[bid]
-        merged.base_span = 1 << order
-        self._link_tail(merged, order)
-        self.num_free_blocks += size_returned
-
-    def append_n(self, blocks: list[KVCacheBlock]) -> None:
-        for b in blocks:
-            self.append(b)
-
-    def prepend_n(self, blocks: list[KVCacheBlock]) -> None:
-        """Return blocks to the pool, prioritized for immediate reuse.
-
-        The LRU queue distinguishes front (reuse-first) from back; the buddy
-        queue has no single global free list, but ``append`` already links an
-        *uncached* freed chunk at the HEAD of its order's LRU (popped before
-        cached chunks), which is exactly the "reuse these next" semantics the
-        ``prepend`` path (e.g. mamba scratch-block recycling in
-        ``remove_skipped_blocks``) wants. So prepend reduces to append here."""
-        for b in blocks:
-            self.append(b)
-
+    # ---------------------------- introspection -----------------------------
     def get_all_free_blocks(self) -> list[KVCacheBlock]:
-        """Return all free chunk heads in iteration order (head → tail per
-        order, low order to high order, then tail-fallback ids). Intended
-        for tests/introspection."""
+        """All truly-free chunk heads (pool, low order to high, then tail-
+        fallback ids). Excludes reclaim candidates. For tests/introspection."""
         out: list[KVCacheBlock] = []
         for k in range(self._max_order + 1):
             cur = self._heads[k].next_free_block
@@ -486,3 +315,7 @@ class BuddyFreeKVCacheBlockQueue:
                 cur = cur.next_free_block
         out.extend(self._blocks_by_id[bid] for bid in self._tail_free)
         return out
+
+    def reclaimable_chunks(self) -> Sequence[KVCacheBlock]:
+        """Cached reclaim candidates held by the eviction policy."""
+        return self._evictor.reclaimable_chunks()

--- a/vllm/v1/core/buddy_free_queue.py
+++ b/vllm/v1/core/buddy_free_queue.py
@@ -1,0 +1,488 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-order LRU buddy-backed free queue.
+
+Drop-in replacement for ``FreeKVCacheBlockQueue`` when variable-size
+allocations are needed. Differences vs. the LRU queue:
+
+- Free blocks are organised as one doubly-linked LRU list **per buddy order**.
+  Each list threads through the ``prev_free_block`` / ``next_free_block``
+  attributes of ``KVCacheBlock`` (same pointer slots the LRU queue uses, so a
+  block lives in at most one queue at a time).
+- ``alloc_chunk(order)`` pops the LRU head of that order's list; if empty it
+  walks up, pops a larger chunk, and splits — pushing the buddy half(ves)
+  back into lower-order LRU tails. Returns the head block with
+  ``base_span = 2**order`` recorded on it.
+- ``append(block)`` reads ``block.base_span``, attempts eager coalesce with
+  its buddy if the buddy is also free at the same order, otherwise links the
+  block into the appropriate order's LRU tail.
+- ``remove(block)`` reads ``block.base_span`` and unlinks the block from
+  its LRU in O(1) — no order parameter, same signature as the LRU queue's
+  ``remove``. The chunk leaves the free pool entirely; the caller is
+  responsible for tracking it.
+- ``popleft()`` and ``popleft_n()`` delegate to ``alloc_chunk(order=0)``.
+
+The structure preserves the buddy invariant that a free chunk at order ``k``
+starts at an id that is a multiple of ``2**k``, but storage is now per-order
+LRU rather than per-order sets.
+
+Prefix-cache fragmentation policy (preserve-cached): a cached chunk (one whose
+``block_hash`` is set) is preserved, not merged away. ``append`` refuses to
+coalesce two buddies if either side holds a cache hash, so a cached chunk keeps
+its identity and can still serve a prefix-cache hit. A cached chunk only loses
+its hash when an allocation must reclaim its memory — either it is popped to
+satisfy a same-order request after all uncached chunks are exhausted, or it is
+split to satisfy a smaller request. In both cases ``on_evict`` fires *before*
+the structural change so the prefix-cache hash map never retains a stale entry,
+and memory reused by a new request never carries a previous owner's hash. The
+cost of preserving cached chunks is potential fragmentation under cache
+pressure; that is a throughput trade-off, not a correctness issue — allocation
+remains correct because it falls back to evicting cached chunks when needed.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+
+def _make_sentinel(block_id: int = -1) -> KVCacheBlock:
+    """Fake head/tail node — never returned to callers."""
+    return KVCacheBlock(block_id=block_id)
+
+
+class BuddyFreeKVCacheBlockQueue:
+    def __init__(
+        self,
+        blocks: list[KVCacheBlock],
+        max_order: int = 0,
+        on_evict: Callable[[KVCacheBlock], bool] | None = None,
+    ) -> None:
+        """Args:
+        blocks: One ``KVCacheBlock`` per base-block id, ordered by id.
+        max_order: Largest buddy order. ``2**max_order`` need not divide
+            ``len(blocks)``; any tail ids beyond the largest aligned
+            prefix are added as order-0 chunks (cannot coalesce up).
+        on_evict: Optional callback fired before a cached chunk loses
+            its identity due to a split (in ``alloc_chunk``) or a
+            coalesce (in ``append``). The callback should drop the
+            block's hash from the prefix-cache map and call
+            ``block.reset_hash()``. Signature mirrors
+            ``BlockPool._maybe_evict_cached_block``: returns True if
+            anything was evicted; the return value is ignored here.
+            When ``None`` (default), no eviction is performed — only
+            safe when prefix caching is disabled at the pool level.
+        """
+        if max_order < 0:
+            raise ValueError(f"max_order must be non-negative, got {max_order}")
+        n = len(blocks)
+        if n == 0:
+            raise ValueError("blocks must be non-empty")
+        self._max_order = max_order
+        self._on_evict = on_evict
+        self._blocks_by_id: dict[int, KVCacheBlock] = {b.block_id: b for b in blocks}
+
+        # Per-order LRU: heads[k] -> ... -> tails[k]. Lowest id at head end
+        # initially; subsequent appends go to the tail (= MRU end).
+        self._heads: list[KVCacheBlock] = [
+            _make_sentinel() for _ in range(max_order + 1)
+        ]
+        self._tails: list[KVCacheBlock] = [
+            _make_sentinel() for _ in range(max_order + 1)
+        ]
+        for k in range(max_order + 1):
+            self._heads[k].next_free_block = self._tails[k]
+            self._tails[k].prev_free_block = self._heads[k]
+
+        # Seed the largest aligned prefix as max-order chunks. Any tail ids
+        # (not a multiple of 2**max_order from 0) live in a side fallback
+        # list, NOT in the order-0 LRU. Two reasons:
+        # 1. ``NULL_BLOCK_ID = 0`` is hardcoded in the attention/mamba
+        #    kernels — they assume the first popleft() (which becomes
+        #    BlockPool.null_block) returns id 0. Keeping order-0 LRU empty
+        #    at init means popleft must walk up to max_order, where the
+        #    LRU head is block 0, and splits down through the low halves
+        #    to return block 0.
+        # 2. Tail blocks can't form valid buddy chunks (their buddies
+        #    would be out-of-range), so eager coalesce would waste cycles
+        #    checking buddies that don't exist. Keeping them in a side
+        #    list lets popleft drain the aligned pool first and only fall
+        #    back to tail blocks under pressure.
+        chunk = 1 << max_order
+        aligned_n = (n // chunk) * chunk
+        if aligned_n == 0:
+            raise ValueError(
+                f"len(blocks)={n} too small for max_order={max_order} "
+                f"(need at least {chunk})"
+            )
+        # ``_link_tail`` puts uncached blocks at the LRU HEAD (so they pop
+        # first), which means each insert pushes earlier inserts back. Seed
+        # in REVERSE id order so that block 0 ends up at the head — this
+        # preserves the NULL_BLOCK_ID = 0 invariant: the very first popleft
+        # (which BlockPool consumes as the null block) returns id 0.
+        for start in range(aligned_n - chunk, -1, -chunk):
+            head = blocks[start]
+            head.base_span = 1 << max_order
+            self._link_tail(head, max_order)
+        # Tail blocks: pop from the end (LIFO) so iterating popleft sees
+        # higher ids first, matching the LRU-queue convention that initial
+        # block order is by id.
+        self._tail_free: list[int] = list(range(aligned_n, n))
+        self._tail_allocated: set[int] = set()
+
+        self.num_free_blocks: int = n
+
+    # ----------------------- LRU linked-list helpers ------------------------
+    def _link_tail(self, block: KVCacheBlock, order: int) -> None:
+        """Insert ``block`` at the MRU end of order ``order``.
+
+        Cached blocks (``block_hash is not None``) go to the TAIL — they age
+        out via LRU and are evicted last. Uncached blocks go to the HEAD so
+        they are popped first, preserving cached chunks. Combined with the
+        coalesce-skip rule in ``append``, this means the order-K LRU layout
+        is: ``[uncached newest → ... → uncached oldest][cached oldest → ...
+        → cached newest]``. The head's hash state tells us in O(1) whether
+        any uncached chunk exists at this order — used by ``alloc_chunk``
+        to prefer splitting a higher-order uncached chunk over evicting a
+        same-order cached one.
+        """
+        if block.block_hash is None:
+            # Uncached: link at HEAD so it pops first.
+            head = self._heads[order]
+            nxt = head.next_free_block
+            assert nxt is not None
+            head.next_free_block = block
+            block.prev_free_block = head
+            block.next_free_block = nxt
+            nxt.prev_free_block = block
+        else:
+            # Cached: link at TAIL (MRU end) for LRU eviction.
+            tail = self._tails[order]
+            prev = tail.prev_free_block
+            assert prev is not None
+            prev.next_free_block = block
+            block.prev_free_block = prev
+            block.next_free_block = tail
+            tail.prev_free_block = block
+
+    def _unlink(self, block: KVCacheBlock) -> None:
+        """Unlink ``block`` from whatever per-order LRU it's currently in."""
+        prev = block.prev_free_block
+        nxt = block.next_free_block
+        if prev is None or nxt is None:
+            raise RuntimeError(f"_unlink called on block not in any LRU: {block}")
+        prev.next_free_block = nxt
+        nxt.prev_free_block = prev
+        block.prev_free_block = None
+        block.next_free_block = None
+
+    def _pop_head(self, order: int) -> KVCacheBlock | None:
+        """Pop the LRU head of order ``order``, or None if empty."""
+        head = self._heads[order]
+        first = head.next_free_block
+        assert first is not None
+        if first is self._tails[order]:
+            return None
+        self._unlink(first)
+        return first
+
+    def _is_in_queue(self, block: KVCacheBlock) -> bool:
+        return block.prev_free_block is not None and block.next_free_block is not None
+
+    # --------------------------- public surface -----------------------------
+    @property
+    def max_order(self) -> int:
+        return self._max_order
+
+    def popleft(self) -> KVCacheBlock:
+        """Single base-block alloc (= alloc_chunk(0))."""
+        return self.alloc_chunk(order=0)
+
+    def popleft_n(self, n: int) -> list[KVCacheBlock]:
+        if n == 0:
+            return []
+        if n > self.num_free_blocks:
+            raise ValueError(
+                f"Cannot pop {n} blocks (only {self.num_free_blocks} free)"
+            )
+        return [self.alloc_chunk(order=0) for _ in range(n)]
+
+    def alloc_chunk(self, order: int) -> KVCacheBlock:
+        """Allocate a chunk of ``2**order`` base blocks.
+
+        Returns the head ``KVCacheBlock`` of the chunk (start id), with
+        ``base_span = 2**order`` set on it.
+        """
+        if order < 0 or order > self._max_order:
+            raise ValueError(f"order {order} out of range [0, {self._max_order}]")
+        # Pass 1: prefer an UNCACHED chunk to avoid evicting a cached one.
+        # Because _link_tail puts uncached blocks at the HEAD of each order's
+        # LRU, checking the head's hash is an O(1) test for "any uncached
+        # chunk available at this order". We walk up looking for the smallest
+        # order whose head is uncached.
+        src = order
+        while src <= self._max_order:
+            head = self._heads[src].next_free_block
+            if head is not self._tails[src] and head.block_hash is None:
+                break
+            src += 1
+        if src > self._max_order:
+            # Pass 2: no uncached chunk anywhere. Fall back to evicting the
+            # LRU-head cached chunk at the smallest non-empty order.
+            src = order
+            while src <= self._max_order:
+                if self._heads[src].next_free_block is not self._tails[src]:
+                    break
+                src += 1
+        if src > self._max_order:
+            # Fall back to tail blocks for order-0 requests only — tail
+            # ids aren't aligned for higher orders.
+            if order == 0 and self._tail_free:
+                bid = self._tail_free.pop()
+                self._tail_allocated.add(bid)
+                self.num_free_blocks -= 1
+                blk = self._blocks_by_id[bid]
+                blk.base_span = 1
+                return blk
+            raise ValueError(f"No free chunk of order >= {order} available")
+        block = self._pop_head(src)
+        assert block is not None
+        # If the popped chunk is cached, drop its hash before reusing the
+        # memory. This covers both same-order eviction (src == order, no
+        # uncached found) and the older split-on-cached case (src > order
+        # — should be rare with the uncached-first pass but possible if a
+        # higher-order chunk got cached somehow).
+        if self._on_evict is not None and block.block_hash is not None:
+            self._on_evict(block)
+        # Split src -> order: at each level, the high-half buddy goes into
+        # its order's LRU tail; the low half continues down.
+        while src > order:
+            src -= 1
+            buddy_id = block.block_id + (1 << src)
+            buddy = self._blocks_by_id[buddy_id]
+            buddy.base_span = 1 << src
+            self._link_tail(buddy, src)
+        block.base_span = 1 << order
+        self.num_free_blocks -= 1 << order
+        return block
+
+    def can_allocate_chunks(self, order: int, num_chunks: int) -> bool:
+        """Whether ``num_chunks`` chunks of ``2**order`` base blocks can be
+        carved from the current free structure.
+
+        A free chunk at order ``j >= order`` can be split into
+        ``2**(j-order)`` chunks of ``order``, so the achievable count is the
+        sum of those contributions across all orders ``>= order`` (plus the
+        unaligned tail-fallback ids for ``order == 0``). Admission uses this so
+        a request that fits in raw base-block count but cannot be satisfied due
+        to buddy alignment/fragmentation is rejected up front rather than
+        failing mid-allocation. This counts structural capacity; cached chunks
+        are included because allocation evicts them when needed.
+        """
+        if num_chunks <= 0:
+            return True
+        if order < 0 or order > self._max_order:
+            return False
+        capacity = 0
+        for j in range(order, self._max_order + 1):
+            count = 0
+            cur = self._heads[j].next_free_block
+            tail = self._tails[j]
+            while cur is not None and cur is not tail:
+                count += 1
+                cur = cur.next_free_block
+            capacity += count << (j - order)
+            if capacity >= num_chunks:
+                return True
+        if order == 0:
+            capacity += len(self._tail_free)
+        return capacity >= num_chunks
+
+    def can_allocate_demands(self, demand: dict[int, int]) -> bool:
+        """Whether a joint demand of ``{order: num_chunks}`` can be satisfied
+        from the current (eagerly-coalesced) free structure.
+
+        Allocations from the shared pool compete: carving high-order chunks
+        removes base blocks that lower orders could otherwise use. For a buddy
+        system whose free chunks are maximally coalesced, a multiset of
+        power-of-two requests is satisfiable iff, for every order threshold
+        ``k``, the base blocks demanded by orders ``>= k`` do not exceed the
+        base blocks held in free chunks of order ``>= k`` (a majorization
+        condition). The ``k == 0`` case reduces to the plain base-block count.
+        Unaligned tail-fallback ids only help order 0.
+        """
+        if not demand:
+            return True
+        free_chunks_per_order = [0] * (self._max_order + 1)
+        for k in range(self._max_order + 1):
+            count = 0
+            cur = self._heads[k].next_free_block
+            tail = self._tails[k]
+            while cur is not None and cur is not tail:
+                count += 1
+                cur = cur.next_free_block
+            free_chunks_per_order[k] = count
+        tail_free = len(self._tail_free)
+
+        for k in range(self._max_order + 1):
+            demand_base = 0
+            for order, num_chunks in demand.items():
+                if num_chunks <= 0:
+                    continue
+                if order < 0 or order > self._max_order:
+                    return False
+                if order >= k:
+                    demand_base += num_chunks << order
+            free_base = sum(
+                free_chunks_per_order[j] << j for j in range(k, self._max_order + 1)
+            )
+            if k == 0:
+                free_base += tail_free
+            if demand_base > free_base:
+                return False
+        return True
+
+    # ------------------- allocator-neutral interface ------------------------
+    @classmethod
+    def for_max_span(
+        cls,
+        blocks: list[KVCacheBlock],
+        max_allocation_span: int,
+        on_evict: Callable[[KVCacheBlock], bool] | None = None,
+    ) -> BuddyFreeKVCacheBlockQueue:
+        """Construct from a neutral max *span* (base blocks per logical block)
+        rather than a buddy order, translating span->order internally. Lets the
+        allocator-agnostic pool size the buddy without speaking "order"."""
+        max_order = (max(1, max_allocation_span) - 1).bit_length()
+        return cls(blocks, max_order=max_order, on_evict=on_evict)
+
+    @staticmethod
+    def normalize_span(natural_span: int) -> int:
+        """Round a natural span up to the next power of two — the only spans
+        this buddy allocator can carve and align. ``normalize_span(3) == 4``,
+        ``normalize_span(4) == 4``, ``normalize_span(1) == 1``. This is the
+        single home of the power-of-two rounding the layout used to inline."""
+        if natural_span <= 1:
+            return 1
+        return 1 << (natural_span - 1).bit_length()
+
+    @staticmethod
+    def _span_to_order(base_span: int) -> int:
+        order = base_span.bit_length() - 1
+        if base_span < 1 or (1 << order) != base_span:
+            raise ValueError(f"base_span must be a power of two, got {base_span}")
+        return order
+
+    def allocate_spanned_block(self, base_span: int) -> KVCacheBlock:
+        """Allocate one logical block spanning ``base_span`` base blocks."""
+        return self.alloc_chunk(self._span_to_order(base_span))
+
+    def free_spanned_block(self, block: KVCacheBlock) -> None:
+        """Return a spanned block to the pool (span read from ``base_span``)."""
+        self.append(block)
+
+    def can_allocate_spans(self, demand_by_span: dict[int, int]) -> bool:
+        """Whether a ``{base_span: num_blocks}`` demand is satisfiable."""
+        demand_by_order: dict[int, int] = {}
+        for base_span, count in demand_by_span.items():
+            if count <= 0:
+                continue
+            order = base_span.bit_length() - 1
+            if base_span < 1 or (1 << order) != base_span:
+                return False
+            demand_by_order[order] = demand_by_order.get(order, 0) + count
+        return self.can_allocate_demands(demand_by_order)
+
+    def free_chunk(self, start_id: int) -> None:
+        """Back-compat: locate the block by id and call ``append`` on it.
+
+        Callers that hold a ``KVCacheBlock`` should prefer ``append(block)``.
+        """
+        self.append(self._blocks_by_id[start_id])
+
+    def remove(self, block: KVCacheBlock) -> None:
+        """Remove ``block`` (a free-chunk head) from its order's LRU.
+
+        Decrements ``num_free_blocks`` by ``block.base_span``. The caller takes
+        ownership of the chunk; ``append(block)`` returns it.
+        """
+        if not self._is_in_queue(block):
+            raise RuntimeError(f"remove called on block not in any LRU: {block}")
+        self._unlink(block)
+        self.num_free_blocks -= block.base_span
+
+    def append(self, block: KVCacheBlock) -> None:
+        """Return ``block`` (head of a chunk of ``block.base_span`` base
+        blocks) to the free pool. Eagerly coalesces with its buddy if also free
+        at the same order, recursively up to ``max_order``."""
+        bid = block.block_id
+        # Tail-block fast path: not part of the buddy address space, just
+        # return to the side fallback list.
+        if bid in self._tail_allocated:
+            self._tail_allocated.discard(bid)
+            self._tail_free.append(bid)
+            self.num_free_blocks += 1
+            return
+        order = block.base_span.bit_length() - 1
+        if order < 0 or order > self._max_order:
+            raise ValueError(
+                f"append: base_span {block.base_span} (order {order}) out of "
+                f"range [0, {self._max_order}] for block {block.block_id}"
+            )
+        # Coalesce as far up as buddies are free.
+        size_returned = 1 << order
+        while order < self._max_order:
+            buddy_id = bid ^ (1 << order)
+            # Tail-region order-0 ids may have no buddy in the pool.
+            buddy = self._blocks_by_id.get(buddy_id)
+            if buddy is None:
+                break
+            if not self._is_in_queue(buddy) or buddy.base_span != (1 << order):
+                break
+            # Preserve cached identity: if either contributor holds a cache
+            # hash, coalescing would discard a valid prefix-cache entry. Stop
+            # and leave both in their order's LRU. They can still be reused
+            # individually; coalescing resumes once both sides are uncached.
+            cur = self._blocks_by_id[bid]
+            if self._on_evict is not None and (
+                cur.block_hash is not None or buddy.block_hash is not None
+            ):
+                break
+            self._unlink(buddy)
+            bid = min(bid, buddy_id)
+            order += 1
+        merged = self._blocks_by_id[bid]
+        merged.base_span = 1 << order
+        self._link_tail(merged, order)
+        self.num_free_blocks += size_returned
+
+    def append_n(self, blocks: list[KVCacheBlock]) -> None:
+        for b in blocks:
+            self.append(b)
+
+    def prepend_n(self, blocks: list[KVCacheBlock]) -> None:
+        """Return blocks to the pool, prioritized for immediate reuse.
+
+        The LRU queue distinguishes front (reuse-first) from back; the buddy
+        queue has no single global free list, but ``append`` already links an
+        *uncached* freed chunk at the HEAD of its order's LRU (popped before
+        cached chunks), which is exactly the "reuse these next" semantics the
+        ``prepend`` path (e.g. mamba scratch-block recycling in
+        ``remove_skipped_blocks``) wants. So prepend reduces to append here."""
+        for b in blocks:
+            self.append(b)
+
+    def get_all_free_blocks(self) -> list[KVCacheBlock]:
+        """Return all free chunk heads in iteration order (head → tail per
+        order, low order to high order, then tail-fallback ids). Intended
+        for tests/introspection."""
+        out: list[KVCacheBlock] = []
+        for k in range(self._max_order + 1):
+            cur = self._heads[k].next_free_block
+            tail = self._tails[k]
+            while cur is not None and cur is not tail:
+                out.append(cur)
+                cur = cur.next_free_block
+        out.extend(self._blocks_by_id[bid] for bid in self._tail_free)
+        return out

--- a/vllm/v1/core/eviction_policy.py
+++ b/vllm/v1/core/eviction_policy.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""LRU eviction policy for cached KV-cache blocks.
+
+An allocator owns one of these (the "reclaim model"): released-but-cached blocks
+are *tracked* here as reclaim candidates rather than returned to the allocator's
+free structure, so they retain their prefix-cache hash and can still serve a hit.
+When the allocator runs short it calls ``pop_victim`` to reclaim the least-
+recently-used candidate; ``on_evict`` drops that block's hash before its memory
+is reused.
+
+The candidate list is a doubly-linked LRU threaded through the
+``prev_free_block`` / ``next_free_block`` slots of ``KVCacheBlock`` — the same
+slots the free queues use. A block lives in the allocator's free structure *or*
+in this policy's candidate list, never both, so the pointers never conflict.
+
+Ordering: head = least-recently-used (reclaimed first), tail = most-recently-
+used (reclaimed last). A freshly released candidate is the most recent, so it
+links at the tail; ``prefer_reuse`` (e.g. mamba scratch recycling) links at the
+head so the block is reclaimed/reused first.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+
+def _make_sentinel() -> KVCacheBlock:
+    """Fake head/tail node — never returned to callers."""
+    return KVCacheBlock(block_id=-1)
+
+
+class LRUEvictionPolicy:
+    def __init__(
+        self,
+        on_evict: Callable[[KVCacheBlock], bool] | None = None,
+    ) -> None:
+        """Args:
+        on_evict: Fired on the block ``pop_victim`` is about to surrender,
+            before its memory is reused. Should drop the block's hash from the
+            prefix-cache map and reset it (mirrors
+            ``BlockPool._maybe_evict_cached_block``); the return value is
+            ignored. ``None`` only when prefix caching is disabled (nothing is
+            ever tracked, so it never fires).
+        """
+        self._on_evict = on_evict
+        self._head = _make_sentinel()
+        self._tail = _make_sentinel()
+        self._head.next_free_block = self._tail
+        self._tail.prev_free_block = self._head
+        self.num_reclaimable: int = 0
+
+    def _unlink(self, block: KVCacheBlock) -> None:
+        prev = block.prev_free_block
+        nxt = block.next_free_block
+        assert prev is not None and nxt is not None
+        prev.next_free_block = nxt
+        nxt.prev_free_block = prev
+        block.prev_free_block = None
+        block.next_free_block = None
+
+    def track(self, block: KVCacheBlock, *, prefer_reuse: bool = False) -> None:
+        if prefer_reuse:
+            # Reclaim/reuse first: link at the LRU (head) end.
+            anchor = self._head
+            nxt = anchor.next_free_block
+            assert nxt is not None
+            anchor.next_free_block = block
+            block.prev_free_block = anchor
+            block.next_free_block = nxt
+            nxt.prev_free_block = block
+        else:
+            # Most-recently-used: link at the tail end (reclaimed last).
+            anchor = self._tail
+            prev = anchor.prev_free_block
+            assert prev is not None
+            prev.next_free_block = block
+            block.prev_free_block = prev
+            block.next_free_block = anchor
+            anchor.prev_free_block = block
+        self.num_reclaimable += block.base_span
+
+    def untrack(self, block: KVCacheBlock) -> None:
+        if block.prev_free_block is None or block.next_free_block is None:
+            raise RuntimeError(f"untrack called on a block not tracked here: {block}")
+        self._unlink(block)
+        self.num_reclaimable -= block.base_span
+
+    def pop_victim(self) -> KVCacheBlock | None:
+        victim = self._head.next_free_block
+        assert victim is not None
+        if victim is self._tail:
+            return None
+        self._unlink(victim)
+        self.num_reclaimable -= victim.base_span
+        if self._on_evict is not None:
+            self._on_evict(victim)
+        return victim
+
+    def reclaimable_chunks(self) -> list[KVCacheBlock]:
+        out: list[KVCacheBlock] = []
+        cur = self._head.next_free_block
+        while cur is not None and cur is not self._tail:
+            out.append(cur)
+            cur = cur.next_free_block
+        return out

--- a/vllm/v1/core/kv_cache_allocator.py
+++ b/vllm/v1/core/kv_cache_allocator.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Allocator-neutral interface for the KV-cache free-block pool.
+
+``BlockPool`` owns a free-block allocator behind this interface so the
+allocation strategy is swappable. Two implementations satisfy it today: the
+default LRU ``FreeKVCacheBlockQueue`` and the variable-span
+``BuddyFreeKVCacheBlockQueue``. The vocabulary here is deliberately
+allocator-agnostic — callers speak in blocks and counts, never in
+implementation concepts such as buddy orders or bit arithmetic. Any
+strategy-specific capability (e.g. variable-span chunk allocation) lives behind
+the pool, not in the generic KV-cache managers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from vllm.v1.core.kv_cache_utils import KVCacheBlock
+
+
+@runtime_checkable
+class KVCacheBlockAllocator(Protocol):
+    """The free-block management surface a ``BlockPool`` depends on.
+
+    Implementations maintain the set of free blocks (including eviction
+    candidates when prefix caching is enabled) and thread each block through a
+    single intrusive free list at a time. A block is in at most one allocator.
+    Callers must not rely on a particular ordering of free blocks beyond the
+    documented LRU/eviction semantics of the concrete implementation.
+    """
+
+    # Number of free base blocks currently available.
+    num_free_blocks: int
+
+    def popleft(self) -> KVCacheBlock:
+        """Remove and return the next free block to hand out."""
+        ...
+
+    def popleft_n(self, n: int) -> list[KVCacheBlock]:
+        """Remove and return the next ``n`` free blocks."""
+        ...
+
+    def append(self, block: KVCacheBlock) -> None:
+        """Return a block to the free pool."""
+        ...
+
+    def append_n(self, blocks: list[KVCacheBlock]) -> None:
+        """Return several blocks to the free pool."""
+        ...
+
+    def prepend_n(self, blocks: list[KVCacheBlock]) -> None:
+        """Return several blocks to the free pool, prioritized for immediate
+        reuse (the next allocations should prefer them). An allocator with no
+        global reuse ordering may treat this the same as ``append_n``."""
+        ...
+
+    def remove(self, block: KVCacheBlock) -> None:
+        """Take a specific block out of the free pool (caller owns it)."""
+        ...
+
+    def get_all_free_blocks(self) -> list[KVCacheBlock]:
+        """Return all currently-free blocks (for introspection/tests)."""
+        ...
+
+    def allocate_spanned_block(self, base_span: int) -> KVCacheBlock:
+        """Allocate one logical block spanning ``base_span`` consecutive base
+        blocks and return its starting block. ``base_span == 1`` is the
+        ordinary single-base-block allocation. Implementations that only
+        support single-base-block allocation must raise for ``base_span > 1``.
+        """
+        ...
+
+    def free_spanned_block(self, block: KVCacheBlock) -> None:
+        """Return a block previously obtained from ``allocate_spanned_block``
+        to the free pool (its span is recovered from allocator-internal
+        bookkeeping)."""
+        ...
+
+    def can_allocate_spans(self, demand_by_span: dict[int, int]) -> bool:
+        """Whether a joint demand of ``{base_span: num_blocks}`` can be
+        satisfied from the current free structure, accounting for any
+        alignment/fragmentation the implementation imposes."""
+        ...
+
+    @staticmethod
+    def normalize_span(natural_span: int) -> int:
+        """Round a requested *natural* span (the number of base blocks a
+        logical block needs to cover its page) up to the granularity this
+        allocator can actually hand out and align starts to.
+
+        The layout sizes tensors and computes logical<->base block-id
+        translation (``block_id // base_span``) from the returned value, so
+        every consumer must agree on one effective span. The contract is that
+        the allocator aligns each spanned chunk's start id to a multiple of the
+        returned span. Allocators that support arbitrary spans return
+        ``natural_span`` unchanged; the buddy allocator rounds up to the next
+        power of two. A span-1-only allocator returns 1 and rejects anything
+        larger. This is a static capability because the layout is resolved
+        before any allocator instance exists.
+        """
+        ...

--- a/vllm/v1/core/kv_cache_allocator.py
+++ b/vllm/v1/core/kv_cache_allocator.py
@@ -1,15 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Allocator-neutral interface for the KV-cache free-block pool.
+"""Allocator + eviction-policy interfaces for the KV-cache free-block pool.
 
-``BlockPool`` owns a free-block allocator behind this interface so the
-allocation strategy is swappable. Two implementations satisfy it today: the
-default LRU ``FreeKVCacheBlockQueue`` and the variable-span
-``BuddyFreeKVCacheBlockQueue``. The vocabulary here is deliberately
-allocator-agnostic — callers speak in blocks and counts, never in
-implementation concepts such as buddy orders or bit arithmetic. Any
-strategy-specific capability (e.g. variable-span chunk allocation) lives behind
-the pool, not in the generic KV-cache managers.
+``BlockPool`` depends only on ``BlockAllocator``: a real-allocator surface of
+``allocate`` / ``free`` (plus ``reuse`` for prefix-cache hits and a feasibility
+query). The allocation strategy is swappable behind it. Two implementations
+satisfy it today: the default LRU ``FreeKVCacheBlockQueue`` and the
+variable-span ``BuddyAllocator``.
+
+Prefix-cache eviction is a separate concern, modelled by ``EvictionPolicy``. An
+allocator *owns* an eviction policy and reclaims from it internally when free
+memory runs short — ``BlockPool`` never orchestrates reclaim. Cached-but-
+reusable blocks live in the policy (the "reclaim model"), so the allocator's
+free structure only ever holds truly-free memory. The policy carries an
+``on_evict`` hook that drops the reclaimed block's hash from the prefix-cache
+map (owned by ``BlockPool``); ``BlockPool`` keeps the map for lookup/insert and
+signals a hit via ``BlockAllocator.reuse``.
+
+The vocabulary here is deliberately allocator-agnostic — callers speak in blocks
+and spans (base-block counts), never in implementation concepts such as buddy
+orders or bit arithmetic.
 """
 
 from __future__ import annotations
@@ -17,70 +27,60 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from vllm.v1.core.kv_cache_utils import KVCacheBlock
 
 
 @runtime_checkable
-class KVCacheBlockAllocator(Protocol):
-    """The free-block management surface a ``BlockPool`` depends on.
+class BlockAllocator(Protocol):
+    """The allocation surface ``BlockPool`` depends on.
 
-    Implementations maintain the set of free blocks (including eviction
-    candidates when prefix caching is enabled) and thread each block through a
-    single intrusive free list at a time. A block is in at most one allocator.
-    Callers must not rely on a particular ordering of free blocks beyond the
-    documented LRU/eviction semantics of the concrete implementation.
+    An implementation manages the set of truly-free blocks and reclaims from its
+    own eviction policy when short. A block is in at most one allocator. Callers
+    must not rely on a particular ordering of free blocks beyond the documented
+    semantics of the concrete implementation.
     """
 
-    # Number of free base blocks currently available.
+    # Base blocks available to satisfy allocations: truly-free memory plus the
+    # reclaimable (cached eviction-candidate) blocks the policy holds.
     num_free_blocks: int
 
-    def popleft(self) -> KVCacheBlock:
-        """Remove and return the next free block to hand out."""
-        ...
+    def allocate(self, span: int = 1) -> KVCacheBlock:
+        """Allocate one logical block spanning ``span`` consecutive base blocks
+        and return its starting block. ``span == 1`` (the default) is the
+        ordinary single-base-block allocation.
 
-    def popleft_n(self, n: int) -> list[KVCacheBlock]:
-        """Remove and return the next ``n`` free blocks."""
-        ...
-
-    def append(self, block: KVCacheBlock) -> None:
-        """Return a block to the free pool."""
-        ...
-
-    def append_n(self, blocks: list[KVCacheBlock]) -> None:
-        """Return several blocks to the free pool."""
-        ...
-
-    def prepend_n(self, blocks: list[KVCacheBlock]) -> None:
-        """Return several blocks to the free pool, prioritized for immediate
-        reuse (the next allocations should prefer them). An allocator with no
-        global reuse ordering may treat this the same as ``append_n``."""
-        ...
-
-    def remove(self, block: KVCacheBlock) -> None:
-        """Take a specific block out of the free pool (caller owns it)."""
-        ...
-
-    def get_all_free_blocks(self) -> list[KVCacheBlock]:
-        """Return all currently-free blocks (for introspection/tests)."""
-        ...
-
-    def allocate_spanned_block(self, base_span: int) -> KVCacheBlock:
-        """Allocate one logical block spanning ``base_span`` consecutive base
-        blocks and return its starting block. ``base_span == 1`` is the
-        ordinary single-base-block allocation. Implementations that only
-        support single-base-block allocation must raise for ``base_span > 1``.
+        When truly-free memory cannot satisfy the request, the allocator
+        reclaims LRU eviction candidates from its policy (dropping their cached
+        hashes) and retries, so the returned memory never carries a stale hash.
+        Raises if the request cannot be satisfied even after reclaiming.
+        Implementations that only support single-base-block allocation must
+        raise for ``span > 1``.
         """
         ...
 
-    def free_spanned_block(self, block: KVCacheBlock) -> None:
-        """Return a block previously obtained from ``allocate_spanned_block``
-        to the free pool (its span is recovered from allocator-internal
-        bookkeeping)."""
+    def free(self, block: KVCacheBlock, *, prefer_reuse: bool = False) -> None:
+        """Return a block previously obtained from ``allocate``.
+
+        A block that still carries a prefix-cache hash becomes a reclaim
+        candidate (retained by the eviction policy for a possible future hit);
+        an uncached block returns to truly-free memory. ``prefer_reuse``
+        prioritises the block for the next allocation (e.g. mamba scratch-block
+        recycling); allocators with no global reuse ordering may ignore it. The
+        block's span is recovered from allocator-internal bookkeeping.
+        """
         ...
 
-    def can_allocate_spans(self, demand_by_span: dict[int, int]) -> bool:
-        """Whether a joint demand of ``{base_span: num_blocks}`` can be
-        satisfied from the current free structure, accounting for any
+    def reuse(self, block: KVCacheBlock) -> None:
+        """Take a specific cached eviction-candidate back out of the free
+        structure because a prefix-cache hit is reusing it (caller owns it
+        again). Mirrors a touch on a ref-count-zero cached block."""
+        ...
+
+    def can_allocate(self, demand_by_span: dict[int, int]) -> bool:
+        """Whether a joint demand of ``{span: num_blocks}`` can be satisfied
+        from free memory plus reclaimable candidates, accounting for any
         alignment/fragmentation the implementation imposes."""
         ...
 
@@ -91,13 +91,49 @@ class KVCacheBlockAllocator(Protocol):
         allocator can actually hand out and align starts to.
 
         The layout sizes tensors and computes logical<->base block-id
-        translation (``block_id // base_span``) from the returned value, so
-        every consumer must agree on one effective span. The contract is that
-        the allocator aligns each spanned chunk's start id to a multiple of the
+        translation (``block_id // span``) from the returned value, so every
+        consumer must agree on one effective span. The contract is that the
+        allocator aligns each spanned chunk's start id to a multiple of the
         returned span. Allocators that support arbitrary spans return
         ``natural_span`` unchanged; the buddy allocator rounds up to the next
         power of two. A span-1-only allocator returns 1 and rejects anything
         larger. This is a static capability because the layout is resolved
         before any allocator instance exists.
         """
+        ...
+
+
+@runtime_checkable
+class EvictionPolicy(Protocol):
+    """Holds released-but-cached blocks as reclaim candidates, in reuse-priority
+    order, and reclaims them on demand.
+
+    A ``BlockAllocator`` owns one of these. It is constructed with an
+    ``on_evict`` hook that drops a reclaimed block's hash from the prefix-cache
+    map (and resets the block's hash) the moment the block is about to be reused
+    for different memory.
+    """
+
+    # Total base blocks held as reclaim candidates (sum of candidate spans).
+    num_reclaimable: int
+
+    def track(self, block: KVCacheBlock, *, prefer_reuse: bool = False) -> None:
+        """Record ``block`` (released by a request but still cached) as a
+        reclaim candidate. ``prefer_reuse`` puts it at the reuse-soon end."""
+        ...
+
+    def untrack(self, block: KVCacheBlock) -> None:
+        """Remove a specific candidate from the structure (a prefix-cache hit is
+        reusing it)."""
+        ...
+
+    def pop_victim(self) -> KVCacheBlock | None:
+        """Remove and return the least-recently-used candidate, after firing
+        ``on_evict`` to drop its cached hash. ``None`` if there are no
+        candidates to reclaim."""
+        ...
+
+    def reclaimable_chunks(self) -> Sequence[KVCacheBlock]:
+        """All current candidate chunk heads (for the allocator's feasibility
+        fold-in / introspection)."""
         ...

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -22,6 +22,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheSpec,
+    MambaSpec,
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
@@ -35,18 +36,18 @@ def _validate_prefix_cache_retention_interval(
     if retention_interval is None:
         return
 
-    # Retention only sparsifies sliding-window checkpoints for now; every other
-    # manager (full attention, Mamba, chunked-local) caches densely and
-    # ignores it to be conservative.
-    # TODO: Support Mamba/linear attention.
+    # Retention sparsifies sliding-window and Mamba (linear-attention)
+    # checkpoints; full-attention and chunked-local groups cache densely and
+    # ignore it (their hit granularity must stay fine).
     if not any(
-        isinstance(g.kv_cache_spec, SlidingWindowSpec)
+        isinstance(g.kv_cache_spec, (SlidingWindowSpec, MambaSpec))
         for g in kv_cache_config.kv_cache_groups
     ):
         raise ValueError(
             "VLLM_PREFIX_CACHE_RETENTION_INTERVAL is set but this model has "
-            "no sliding-window KV cache group, so retention has no effect. "
-            "Unset it (the feature only applies to sliding-window attention)."
+            "no sliding-window or Mamba KV cache group, so retention has no "
+            "effect. Unset it (it only applies to sliding-window and Mamba "
+            "attention)."
         )
 
     if retention_interval < 0 or retention_interval % scheduler_block_size != 0:
@@ -87,12 +88,24 @@ class KVCacheCoordinator(ABC):
         )
         self.scheduler_block_size = scheduler_block_size
 
+        # A group's logical block can span several base blocks in decoupled
+        # mode (``allocation_base_span`` = max-page / base-page ratio). The pool
+        # must size its allocator to carve the largest such span, or those
+        # allocations are unschedulable. Pass the layout-derived max span (a
+        # neutral base-block count); the allocator sizes itself, so enabling a
+        # variable-span allocator needs no manual tuning.
+        max_allocation_span = max(
+            (g.allocation_base_span for g in kv_cache_config.kv_cache_groups),
+            default=1,
+        )
+
         self.block_pool = BlockPool(
             num_gpu_blocks=kv_cache_config.num_blocks,
             enable_caching=enable_caching,
             hash_block_size=hash_block_size,
             enable_kv_cache_events=enable_kv_cache_events,
             metrics_collector=metrics_collector,
+            max_allocation_span=max_allocation_span,
         )
 
         # KV cache group indices that get the EAGLE last-block drop.
@@ -114,6 +127,7 @@ class KVCacheCoordinator(ABC):
                 dcp_world_size=dcp_world_size,
                 pcp_world_size=pcp_world_size,
                 scheduler_block_size=self.scheduler_block_size,
+                base_span=kv_cache_group.allocation_base_span,
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
@@ -126,7 +140,7 @@ class KVCacheCoordinator(ABC):
             self.retention_interval, self.scheduler_block_size, kv_cache_config
         )
 
-    def get_num_blocks_to_allocate(
+    def get_base_block_demand(
         self,
         request_id: str,
         num_tokens: int,
@@ -135,9 +149,21 @@ class KVCacheCoordinator(ABC):
         total_computed_tokens: int,
         num_tokens_main_model: int,
         apply_admission_cap: bool = False,
-    ) -> int:
+    ) -> tuple[int, dict[int, int]]:
         """
-        Get the number of blocks needed to be allocated for the request.
+        Compute the request's allocation demand for admission.
+
+        Returns a pair ``(total_base_blocks, demand_by_span)`` where:
+
+        * ``total_base_blocks`` is the total demand in base-block units (each
+          group's logical-block demand scaled by its allocation span), to be
+          compared against the block pool's base-block free count.
+        * ``demand_by_span`` maps a group's allocation span (base blocks per
+          logical block) to the number of logical blocks demanded at that span,
+          so the allocator can also check alignment/fragmentation feasibility.
+          In the uniform-page path every group spans one base block, so the
+          total equals the logical-block demand and the map has a single
+          ``{1: n}`` entry.
 
         Args:
             request_id: The request ID.
@@ -155,16 +181,14 @@ class KVCacheCoordinator(ABC):
                 per-request admission cap (SWA / chunked-local). Set only by
                 the full-sequence admission gate; per-step allocation must
                 leave it False so the predictor matches `allocate_new_blocks`.
-
-        Returns:
-            The number of blocks to allocate.
         """
-        num_blocks_to_allocate = 0
+        total_base_blocks = 0
+        demand_by_span: dict[int, int] = {}
         for i, manager in enumerate(self.single_type_managers):
             if isinstance(manager, CrossAttentionManager):
                 # For cross-attention, we issue a single static allocation
                 # of blocks based on the number of encoder input tokens.
-                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                num_logical_blocks = manager.get_num_blocks_to_allocate(
                     request_id,
                     num_encoder_tokens,
                     [],
@@ -173,7 +197,7 @@ class KVCacheCoordinator(ABC):
                     apply_admission_cap=apply_admission_cap,
                 )
             else:
-                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                num_logical_blocks = manager.get_num_blocks_to_allocate(
                     request_id,
                     num_tokens,
                     new_computed_blocks[i],
@@ -181,7 +205,38 @@ class KVCacheCoordinator(ABC):
                     num_tokens_main_model,
                     apply_admission_cap=apply_admission_cap,
                 )
-        return num_blocks_to_allocate
+            base_span = manager.base_span
+            total_base_blocks += num_logical_blocks * base_span
+            if num_logical_blocks > 0:
+                demand_by_span[base_span] = (
+                    demand_by_span.get(base_span, 0) + num_logical_blocks
+                )
+        return total_base_blocks, demand_by_span
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        """Total allocation demand in base-block units (the block pool counts
+        base blocks). Thin wrapper over ``get_base_block_demand`` for callers
+        (e.g. the scheduler's reservation accounting) that only need the count;
+        equals the logical-block demand in the uniform-page path (span 1)."""
+        total_base_blocks, _ = self.get_base_block_demand(
+            request_id=request_id,
+            num_tokens=num_tokens,
+            new_computed_blocks=new_computed_blocks,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=total_computed_tokens,
+            num_tokens_main_model=num_tokens_main_model,
+            apply_admission_cap=apply_admission_cap,
+        )
+        return total_base_blocks
 
     def allocate_new_computed_blocks(
         self,
@@ -251,18 +306,32 @@ class KVCacheCoordinator(ABC):
                 blocks for cross-attention.
 
         Returns:
-            The new allocated blocks.
+            The new allocated blocks, one list per group in group order.
         """
-        return tuple(
-            manager.allocate_new_blocks(
+        # Allocate larger-span groups first. Groups share one base-block
+        # address space; a larger span (e.g. a mamba group spanning several
+        # base blocks) needs an aligned multi-base-block chunk, while a span-1
+        # group (attention) can take any base block. Serving the larger spans
+        # before the span-1 groups prevents span-1 allocations from splitting
+        # the aligned chunks the larger spans require, so a request that passed
+        # the (base-weighted + feasibility) admission check always allocates
+        # successfully. Results are returned in the original group order.
+        order = sorted(
+            range(len(self.single_type_managers)),
+            key=lambda i: self.single_type_managers[i].base_span,
+            reverse=True,
+        )
+        results: list[list[KVCacheBlock]] = [[] for _ in self.single_type_managers]
+        for i in order:
+            manager = self.single_type_managers[i]
+            results[i] = manager.allocate_new_blocks(
                 request_id,
                 num_encoder_tokens
                 if isinstance(manager, CrossAttentionManager)
                 else num_tokens,
                 num_tokens_main_model,
             )
-            for manager in self.single_type_managers
-        )
+        return tuple(results)
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         """

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -373,17 +373,21 @@ class KVCacheManager:
             # First check and fail if the full request sequence won't fit.
             full_num_tokens = min(request.num_tokens, self.max_model_len)
 
-            num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
-                request_id=request.request_id,
-                num_tokens=full_num_tokens,
-                new_computed_blocks=new_computed_block_list,
-                num_encoder_tokens=num_encoder_tokens,
-                total_computed_tokens=total_computed_tokens,
-                num_tokens_main_model=full_num_tokens,
-                apply_admission_cap=True,
+            num_base_blocks_to_allocate, demand_by_span = (
+                self.coordinator.get_base_block_demand(
+                    request_id=request.request_id,
+                    num_tokens=full_num_tokens,
+                    new_computed_blocks=new_computed_block_list,
+                    num_encoder_tokens=num_encoder_tokens,
+                    total_computed_tokens=total_computed_tokens,
+                    num_tokens_main_model=full_num_tokens,
+                    apply_admission_cap=True,
+                )
             )
-            required_blocks = num_blocks_to_allocate + watermark_blocks
+            required_blocks = num_base_blocks_to_allocate + watermark_blocks
             if required_blocks > self.block_pool.get_num_free_blocks():
+                return None
+            if not self.block_pool.can_allocate_demands(demand_by_span):
                 return None
 
         num_tokens_main_model = total_computed_tokens + num_new_tokens
@@ -401,22 +405,27 @@ class KVCacheManager:
             request.request_id, total_computed_tokens
         )
 
-        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
-            request_id=request.request_id,
-            num_tokens=num_tokens_need_slot,
-            new_computed_blocks=new_computed_block_list,
-            num_encoder_tokens=num_encoder_tokens,
-            total_computed_tokens=num_local_computed_tokens
-            + num_external_computed_tokens,
-            num_tokens_main_model=num_tokens_main_model,
+        num_base_blocks_to_allocate, demand_by_span = (
+            self.coordinator.get_base_block_demand(
+                request_id=request.request_id,
+                num_tokens=num_tokens_need_slot,
+                new_computed_blocks=new_computed_block_list,
+                num_encoder_tokens=num_encoder_tokens,
+                total_computed_tokens=num_local_computed_tokens
+                + num_external_computed_tokens,
+                num_tokens_main_model=num_tokens_main_model,
+            )
         )
 
         # Keep `reserved_blocks` free for other in-flight sequences, and an
         # additional watermark of headroom for waiting/preempted admissions.
         available_blocks = self.block_pool.get_num_free_blocks() - reserved_blocks
-        required_blocks = num_blocks_to_allocate + watermark_blocks
+        required_blocks = num_base_blocks_to_allocate + watermark_blocks
         if required_blocks > available_blocks:
             # Cannot allocate new blocks
+            return None
+        if not self.block_pool.can_allocate_demands(demand_by_span):
+            # Cannot satisfy the per-span block demand (fragmentation)
             return None
 
         if (

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -126,9 +126,19 @@ class KVCacheBlock:
     _block_hash: BlockHashWithGroupId | None = None
 
     # Used to construct a doubly linked list for free blocks.
-    # These two attributes should only be manipulated by FreeKVCacheBlockQueue.
+    # These two attributes should only be manipulated by FreeKVCacheBlockQueue
+    # (LRU mode) or BuddyFreeKVCacheBlockQueue (buddy mode). A block lives in
+    # exactly one queue at a time, so the pointers don't conflict.
     prev_free_block: "KVCacheBlock | None" = None
     next_free_block: "KVCacheBlock | None" = None
+
+    # Allocation span: when this block heads an allocated or free chunk, the
+    # chunk covers base-block ids [block_id, block_id + base_span). For the LRU
+    # allocator and for non-head base blocks this stays 1 (a single base
+    # block). Set by the variable-span allocator on alloc/split/coalesce. The
+    # value is the neutral base-block count; the buddy allocator converts it
+    # to/from its internal power-of-two order at its own boundaries.
+    base_span: int = 1
 
     # Whether the block is a null block that should never be cached.
     is_null: bool = False
@@ -393,6 +403,47 @@ class FreeKVCacheBlockQueue:
             curr_block = curr_block.next_free_block
         return ret
 
+    # ------------------- allocator-neutral interface ------------------------
+    def allocate_spanned_block(self, base_span: int) -> KVCacheBlock:
+        """Allocate one logical block. This LRU allocator only supports
+        single-base-block allocations; variable-span allocation requires the
+        buddy allocator."""
+        if base_span != 1:
+            raise ValueError(
+                "FreeKVCacheBlockQueue supports only base_span == 1; "
+                f"got {base_span}. Variable-span allocation requires "
+                "VLLM_USE_BUDDY_BLOCK_POOL=1."
+            )
+        return self.popleft()
+
+    def free_spanned_block(self, block: KVCacheBlock) -> None:
+        """Return a block to the free pool."""
+        self.append(block)
+
+    def can_allocate_spans(self, demand_by_span: dict[int, int]) -> bool:
+        """Whether a ``{base_span: num_blocks}`` demand fits. Only span 1 is
+        supported, so any span > 1 demand is unsatisfiable here."""
+        total = 0
+        for base_span, count in demand_by_span.items():
+            if count <= 0:
+                continue
+            if base_span != 1:
+                return False
+            total += count
+        return total <= self.num_free_blocks
+
+    @staticmethod
+    def normalize_span(natural_span: int) -> int:
+        """This allocator only hands out single base blocks, so the only
+        supported span is 1. A natural span > 1 cannot be represented."""
+        if natural_span <= 1:
+            return 1
+        raise ValueError(
+            "FreeKVCacheBlockQueue supports only span 1; got natural span "
+            f"{natural_span}. Variable-span layouts require "
+            "VLLM_USE_BUDDY_BLOCK_POOL=1."
+        )
+
 
 def need_extra_keys(request: Request) -> bool:
     """Check whether the blocks allocated to this request need extra hash keys.
@@ -636,7 +687,11 @@ def resolve_kv_cache_block_sizes(
     # Mamba groups with block_size != cache_config.block_size
     # (mamba_cache_mode != "align") break divisibility; back off to the
     # scheduler block size.
-    if any(
+    # In buddy-decoupled hybrid mode, attn keeps its small kernel-natural
+    # block_size while mamba uses chunk-aligned block_size; we still want
+    # prefix-cache hashing at attn's fine granularity, so don't back off.
+    decoupled = kv_cache_config.base_page_bytes is not None
+    if not decoupled and any(
         isinstance(g.kv_cache_spec, MambaSpec)
         and g.kv_cache_spec.block_size != cache_config.block_size
         for g in groups
@@ -908,10 +963,17 @@ def get_max_concurrency_for_kv_cache_config(
     max_memory_usage_per_request = num_layer_per_group * max_memory_usage_bytes(
         vllm_config, (group.kv_cache_spec for group in kv_cache_config.kv_cache_groups)
     )
-    memory_per_block = (
-        kv_cache_config.kv_cache_groups[0].kv_cache_spec.page_size_bytes
-        * num_layer_per_group
+    # Bytes per pool block. In decoupled hybrid mode every pool block is one
+    # ``base_page_bytes`` base unit (groups[0]'s native page can be smaller than
+    # the base page — e.g. a mamba/KDA group left un-padded — so reading its
+    # page_size_bytes here would under-state the per-block cost and under-report
+    # concurrency by the base-page/native-page ratio). Fall back to groups[0]'s
+    # page when not decoupled (base_page_bytes is None).
+    per_block_bytes = (
+        kv_cache_config.base_page_bytes
+        or kv_cache_config.kv_cache_groups[0].kv_cache_spec.page_size_bytes
     )
+    memory_per_block = per_block_bytes * num_layer_per_group
     num_block_per_request = cdiv(max_memory_usage_per_request, memory_per_block)
     max_concurrency = kv_cache_config.num_blocks / num_block_per_request
     return max_concurrency
@@ -1244,6 +1306,59 @@ def _get_kv_cache_config_deepseek_v4(
     return num_blocks, kv_cache_tensors
 
 
+def _active_span_normalizer() -> Callable[[int], int]:
+    """Resolve the span-rounding policy of the currently-selected allocator.
+
+    The decoupled layout requests a *natural* span (the base-block count a
+    group's page needs); the allocator owns how that span is rounded to a
+    granularity it can carve and align. The buddy allocator rounds up to a
+    power of two; the LRU allocator only supports span 1. Resolving the policy
+    here keeps the rounding rule out of the layout code. When the registry
+    refactor lands this should resolve from the selected allocator kind rather
+    than the buddy flag.
+    """
+    if envs.VLLM_USE_BUDDY_BLOCK_POOL:
+        from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+
+        return BuddyFreeKVCacheBlockQueue.normalize_span
+    return FreeKVCacheBlockQueue.normalize_span
+
+
+def _decoupled_base_page_and_spans(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> tuple[int, list[int]]:
+    """Base page and per-group allocation span for the decoupled hybrid layout.
+
+    Single source of truth shared by the tensor layout
+    (``get_kv_cache_config_from_groups``) and the capacity estimate
+    (``_max_memory_usage_bytes_from_groups``), so admission planning cannot
+    drift from the realized layout.
+
+    ``base_page`` is anchored to the smallest *attention* page: attention
+    groups read through a strided view that requires one base block per logical
+    block (span 1), so the base page must equal their page. When there are no
+    attention groups it falls back to the smallest page overall. Non-attention
+    (e.g. mamba) groups request ``ceil(page / base_page)`` base blocks, rounded
+    by the active allocator's ``normalize_span``. Returns ``(base_page, spans)``
+    with ``spans[i]`` the span for ``kv_cache_groups[i]``.
+    """
+    normalize_span = _active_span_normalizer()
+    attn_pages = [
+        g.kv_cache_spec.page_size_bytes
+        for g in kv_cache_groups
+        if not isinstance(g.kv_cache_spec, MambaSpec)
+    ]
+    all_pages = [g.kv_cache_spec.page_size_bytes for g in kv_cache_groups]
+    base_page = min(attn_pages) if attn_pages else min(all_pages)
+    spans = [
+        1
+        if not isinstance(g.kv_cache_spec, MambaSpec)
+        else normalize_span(cdiv(g.kv_cache_spec.page_size_bytes, base_page))
+        for g in kv_cache_groups
+    ]
+    return base_page, spans
+
+
 def get_kv_cache_config_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -1307,11 +1422,88 @@ def get_kv_cache_config_from_groups(
         # full.0, sw.0, sw.1: share a Tensor with size=available_memory//2
         # full.1, sw.2: share another Tensor with size=available_memory//2
         group_size = max(len(group.layer_names) for group in kv_cache_groups)
+        assert group_size > 0, "group_size must be greater than 0"
+
+        _buddy_decouple = envs.VLLM_USE_BUDDY_BLOCK_POOL
+        # Buddy-decoupled hybrid mode: groups may have different page sizes.
+        # Anchor base_page to the smallest ATTENTION group's page. Attention
+        # groups go through the kernel-block-expansion strided view (which
+        # requires uniform per-block strides), so they must end up at span 1;
+        # any span > 1 on an attn group would mean the kernel pages within one
+        # logical block aren't laid out at a uniform stride and the strided
+        # view can't represent it.
+        # Non-attention (e.g. mamba) groups handle stride independently in
+        # their own reshape branch and tolerate base_page > their native
+        # page (they pay a one-time per-block over-allocation equal to the
+        # gap). This mirrors what baseline does post-`_align_hybrid_block_
+        # size`: pick the larger natural page as the uniform anchor and pad
+        # the smaller side up.
+        all_page_sizes = [g.kv_cache_spec.page_size_bytes for g in kv_cache_groups]
+        decouple_active = _buddy_decouple and len(set(all_page_sizes)) > 1
+        if decouple_active:
+            # base_page anchor and per-group span come from the shared helper
+            # so the realized layout matches the capacity estimate exactly
+            # (see `_decoupled_base_page_and_spans`). Groups whose native page
+            # is <= base_page collapse to span 1 (they over-allocate by
+            # `base_page - native` per block; that's the "pad mamba up" cost).
+            base_page, spans = _decoupled_base_page_and_spans(kv_cache_groups)
+            max_overhang_bytes = 0
+            for g, span in zip(kv_cache_groups, spans):
+                page = g.kv_cache_spec.page_size_bytes
+                is_attention = not isinstance(g.kv_cache_spec, MambaSpec)
+                # Attention groups must allocate exactly one base block per
+                # logical block (span 1). Attention kernels read through a
+                # strided view whose first physical dimension is the block
+                # index; that view only represents adjacent blocks that sit one
+                # base page apart, so a span>1 attention group cannot be laid
+                # out safely (standard-attention shapes start with a K/V
+                # dimension, not the block index). base_page is anchored to the
+                # smallest attention page, so any attention group whose page
+                # exceeds base_page cannot be represented here.
+                if is_attention and page != base_page:
+                    raise ValueError(
+                        "Decoupled hybrid KV cache requires all attention "
+                        f"groups to share one page size, but found an "
+                        f"attention page of {page} B != base page "
+                        f"{base_page} B. Attention groups must allocate one "
+                        "base block per logical block (span 1)."
+                    )
+                g.allocation_base_span = span
+                # The strided kernel view reads page_size_bytes at offset
+                # block_id * base_page, so the last usable block_id is
+                # num_blocks - (page_size_bytes / base_page). Tensors must
+                # have room for that overhang on the tail. Groups whose
+                # native page is <= base_page contribute zero overhang.
+                overhang = page - base_page
+                if overhang > max_overhang_bytes:
+                    max_overhang_bytes = overhang
+            # num_blocks counts base units. The buddy address space is one
+            # block_id per base unit; each layer-tuple slab holds
+            # num_blocks * base_page bytes plus max_overhang for safe strided
+            # reads at the tail.
+            num_blocks = get_num_blocks(
+                vllm_config, group_size, available_memory, base_page
+            )
+            tensor_size_bytes = base_page * num_blocks + max_overhang_bytes
+            kv_cache_tensors = []
+            for i in range(group_size):
+                shared_by = []
+                for j in range(len(kv_cache_groups)):
+                    if i < len(kv_cache_groups[j].layer_names):
+                        shared_by.append(kv_cache_groups[j].layer_names[i])
+                kv_cache_tensors.append(
+                    KVCacheTensor(size=tensor_size_bytes, shared_by=shared_by)
+                )
+            return KVCacheConfig(
+                num_blocks=num_blocks,
+                kv_cache_tensors=kv_cache_tensors,
+                kv_cache_groups=kv_cache_groups,
+                base_page_bytes=base_page,
+            )
 
         page_size = get_uniform_page_size(
             [group.kv_cache_spec for group in kv_cache_groups]
         )
-        assert group_size > 0, "group_size must be greater than 0"
         num_blocks = get_num_blocks(
             vllm_config, group_size, available_memory, page_size
         )
@@ -1680,7 +1872,13 @@ def get_kv_cache_groups(
     # As KVCacheManager can only allocate memory of one size, we need to unify
     # the page size of the layers. For cases cannot be unified, this function
     # will raise an error.
-    filtered_spec = unify_kv_cache_spec_page_size(filtered_spec)
+    # In buddy-decoupled mode, groups keep their native page sizes; the buddy
+    # allocator handles per-group block sizes by issuing variable-order chunks
+    # over a fine-grained base address space. See base_page_bytes handling in
+    # get_kv_cache_config_from_groups.
+    _buddy_decouple = envs.VLLM_USE_BUDDY_BLOCK_POOL
+    if not _buddy_decouple:
+        filtered_spec = unify_kv_cache_spec_page_size(filtered_spec)
     groups = _get_kv_cache_groups_uniform_page_size(filtered_spec)
 
     # Add hidden-state layers back with page aligned to the common page.
@@ -1782,6 +1980,23 @@ def _max_memory_usage_bytes_from_groups(
     # General case: group_size pools, each shared by one layer per group
     # Memory = group_size * page_size * blocks_for_max_len
     group_size = max(len(group.layer_names) for group in kv_cache_groups)
+    page_sizes = [g.kv_cache_spec.page_size_bytes for g in kv_cache_groups]
+    if len(set(page_sizes)) > 1:
+        # Buddy-decoupled hybrid: per-group native pages differ. Anchor the
+        # base page and per-group span with the SAME helper the tensor layout
+        # uses (`_decoupled_base_page_and_spans`), so the estimated base-block
+        # count matches what the layout actually allocates. Per-base-block cost
+        # below is group_size * base_page, so we count base-blocks per group.
+        base_page, spans = _decoupled_base_page_and_spans(kv_cache_groups)
+        base_blocks_needed = 0
+        for g, span in zip(kv_cache_groups, spans):
+            logical_blocks = cdiv(
+                g.kv_cache_spec.max_memory_usage_bytes(vllm_config),
+                g.kv_cache_spec.page_size_bytes,
+            )
+            base_blocks_needed += logical_blocks * span
+        return group_size * base_page * base_blocks_needed
+
     page_size = get_uniform_page_size(
         [group.kv_cache_spec for group in kv_cache_groups]
     )
@@ -2061,9 +2276,17 @@ def get_kv_cache_configs(
         kv_cache_config.num_blocks = min_num_blocks
 
         # Shrink tensor size proportionally
-        for tensor in kv_cache_config.kv_cache_tensors:
-            assert tensor.size % num_blocks_old == 0
-            tensor.size = tensor.size // num_blocks_old * min_num_blocks
+        if kv_cache_config.base_page_bytes is not None:
+            # Decoupled hybrid: tensor.size = num_blocks * base_page + overhang.
+            # Preserve the overhang; shrink only the base-blocks portion.
+            base_page = kv_cache_config.base_page_bytes
+            for tensor in kv_cache_config.kv_cache_tensors:
+                overhang = tensor.size - num_blocks_old * base_page
+                tensor.size = min_num_blocks * base_page + overhang
+        else:
+            for tensor in kv_cache_config.kv_cache_tensors:
+                assert tensor.size % num_blocks_old == 0
+                tensor.size = tensor.size // num_blocks_old * min_num_blocks
 
         if len(kv_cache_config.kv_cache_groups) > 0:
             max_model_len = vllm_config.model_config.max_model_len

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -127,7 +127,7 @@ class KVCacheBlock:
 
     # Used to construct a doubly linked list for free blocks.
     # These two attributes should only be manipulated by FreeKVCacheBlockQueue
-    # (LRU mode) or BuddyFreeKVCacheBlockQueue (buddy mode). A block lives in
+    # (LRU mode) or BuddyAllocator (buddy mode). A block lives in
     # exactly one queue at a time, so the pointers don't conflict.
     prev_free_block: "KVCacheBlock | None" = None
     next_free_block: "KVCacheBlock | None" = None
@@ -192,9 +192,19 @@ class FreeKVCacheBlockQueue:
 
     Args:
         blocks: A list of KVCacheBlock objects.
+        on_evict: Fired when ``allocate`` hands out a block that still carries a
+            prefix-cache hash, before its memory is reused. Drops the block's
+            hash from the prefix-cache map (mirrors
+            ``BlockPool._maybe_evict_cached_block``). ``None`` when prefix
+            caching is disabled.
     """
 
-    def __init__(self, blocks: list[KVCacheBlock]) -> None:
+    def __init__(
+        self,
+        blocks: list[KVCacheBlock],
+        on_evict: Callable[[KVCacheBlock], bool] | None = None,
+    ) -> None:
+        self._on_evict = on_evict
         self.num_free_blocks = len(blocks)
 
         # Initialize doubly links of consecutive blocks
@@ -403,31 +413,44 @@ class FreeKVCacheBlockQueue:
             curr_block = curr_block.next_free_block
         return ret
 
-    # ------------------- allocator-neutral interface ------------------------
-    def allocate_spanned_block(self, base_span: int) -> KVCacheBlock:
-        """Allocate one logical block. This LRU allocator only supports
-        single-base-block allocations; variable-span allocation requires the
-        buddy allocator."""
-        if base_span != 1:
+    # ----------------------- BlockAllocator surface -------------------------
+    # This LRU queue is the default (fused) allocator: it is its own eviction
+    # policy. Cached eviction candidates stay in the queue (not a separate
+    # structure), so ``allocate`` may hand back a still-cached block and drop
+    # its hash via ``on_evict`` here. Only span 1 is supported; variable-span
+    # layouts require the buddy allocator (VLLM_USE_BUDDY_BLOCK_POOL=1).
+    def allocate(self, span: int = 1) -> KVCacheBlock:
+        if span != 1:
             raise ValueError(
-                "FreeKVCacheBlockQueue supports only base_span == 1; "
-                f"got {base_span}. Variable-span allocation requires "
-                "VLLM_USE_BUDDY_BLOCK_POOL=1."
+                f"FreeKVCacheBlockQueue supports only span == 1; got {span}. "
+                "Variable-span allocation requires VLLM_USE_BUDDY_BLOCK_POOL=1."
             )
-        return self.popleft()
+        block = self.popleft()
+        if self._on_evict is not None and block.block_hash is not None:
+            self._on_evict(block)
+        return block
 
-    def free_spanned_block(self, block: KVCacheBlock) -> None:
-        """Return a block to the free pool."""
-        self.append(block)
+    def free(self, block: KVCacheBlock, *, prefer_reuse: bool = False) -> None:
+        """Return a block to the queue. Cached and uncached blocks both stay in
+        the queue (this allocator is its own eviction policy); ``prefer_reuse``
+        puts it at the front so it is handed out next."""
+        if prefer_reuse:
+            self.prepend_n([block])
+        else:
+            self.append_n([block])
 
-    def can_allocate_spans(self, demand_by_span: dict[int, int]) -> bool:
-        """Whether a ``{base_span: num_blocks}`` demand fits. Only span 1 is
+    def reuse(self, block: KVCacheBlock) -> None:
+        """Prefix-cache hit: take a cached candidate out of the queue."""
+        self.remove(block)
+
+    def can_allocate(self, demand_by_span: dict[int, int]) -> bool:
+        """Whether a ``{span: num_blocks}`` demand fits. Only span 1 is
         supported, so any span > 1 demand is unsatisfiable here."""
         total = 0
-        for base_span, count in demand_by_span.items():
+        for span, count in demand_by_span.items():
             if count <= 0:
                 continue
-            if base_span != 1:
+            if span != 1:
                 return False
             total += count
         return total <= self.num_free_blocks
@@ -1318,9 +1341,9 @@ def _active_span_normalizer() -> Callable[[int], int]:
     than the buddy flag.
     """
     if envs.VLLM_USE_BUDDY_BLOCK_POOL:
-        from vllm.v1.core.buddy_free_queue import BuddyFreeKVCacheBlockQueue
+        from vllm.v1.core.buddy_free_queue import BuddyAllocator
 
-        return BuddyFreeKVCacheBlockQueue.normalize_span
+        return BuddyAllocator.normalize_span
     return FreeKVCacheBlockQueue.normalize_span
 
 

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1442,7 +1442,12 @@ class SinkFullAttentionManager(FullAttentionManager):
         sink_len = kv_cache_spec.sink_len
         assert sink_len is not None and sink_len > 0 and sink_len % self.block_size == 0
         num_sink_block = sink_len // self.block_size
-        self.sink_blocks = self.block_pool.free_block_queue.popleft_n(num_sink_block)
+        # Sink blocks are a one-time static grab held for the manager's
+        # lifetime. Route through the allocator's span-1 allocate so this works
+        # under any allocator (the buddy has no popleft_n).
+        self.sink_blocks = [
+            self.block_pool.allocator.allocate(1) for _ in range(num_sink_block)
+        ]
 
 
 def get_manager_for_kv_cache_spec(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -45,6 +45,7 @@ class SingleTypeKVCacheManager(ABC):
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
         max_admission_blocks_per_request: int | None = None,
+        base_span: int = 1,
     ) -> None:
         """
         Initializes the SingleTypeKVCacheManager.
@@ -88,11 +89,24 @@ class SingleTypeKVCacheManager(ABC):
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
 
+        # Per-group allocation span: one logical block of this group spans
+        # ``_base_span`` base blocks. The single source of truth is the group's
+        # spec/config, passed in as base_span by the coordinator; attention
+        # groups are always 1 (one base block per logical block).
+        self._base_span = base_span
+
         # Whether this group's prefix-cache hits drop the EAGLE/MTP lookahead
         # block. Only consulted by managers whose hit logic is sparse within an
         # aligned segment (SWA). Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+
+    @property
+    def base_span(self) -> int:
+        """Allocation span: one logical block spans ``base_span`` base blocks.
+        The single source of truth is the group's spec/config; attention groups
+        are always 1."""
+        return self._base_span
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -264,7 +278,8 @@ class SingleTypeKVCacheManager(ABC):
 
         req_blocks = self.req_to_blocks[request_id]
         allocated_blocks = self.block_pool.get_new_blocks(
-            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
+            cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks),
+            base_span=self._base_span,
         )
         req_blocks.extend(allocated_blocks)
         if type(self.kv_cache_spec) in (
@@ -272,7 +287,13 @@ class SingleTypeKVCacheManager(ABC):
             TQFullAttentionSpec,
             MLAAttentionSpec,
         ):
-            self.new_block_ids.extend(b.block_id for b in allocated_blocks)
+            # The allocator returns blocks identified by their base-block
+            # start id; publish the logical id by dividing by the span
+            # (BlockTable's hybrid-block expansion later multiplies the
+            # published id by the span to reach the kernel row).
+            self.new_block_ids.extend(
+                b.block_id // self._base_span for b in allocated_blocks
+            )
 
     def allocate_new_blocks(
         self, request_id: str, num_tokens: int, num_tokens_main_model: int
@@ -297,14 +318,18 @@ class SingleTypeKVCacheManager(ABC):
         if num_new_blocks <= 0:
             return []
         else:
-            new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+            new_blocks = self.block_pool.get_new_blocks(
+                num_new_blocks, base_span=self._base_span
+            )
             req_blocks.extend(new_blocks)
             if type(self.kv_cache_spec) in (
                 FullAttentionSpec,
                 TQFullAttentionSpec,
                 MLAAttentionSpec,
             ):
-                self.new_block_ids.extend(b.block_id for b in new_blocks)
+                self.new_block_ids.extend(
+                    b.block_id // self._base_span for b in new_blocks
+                )
             return new_blocks
 
     def take_new_block_ids(self) -> list[int]:
@@ -1044,6 +1069,75 @@ class MambaManager(SingleTypeKVCacheManager):
 
         return computed_blocks
 
+    @classmethod
+    def reachable_block_mask(
+        cls,
+        start_block: int,
+        end_block: int,
+        alignment_tokens: int | None,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        retention_interval: int | None = None,
+        num_prompt_tokens: int | None = None,
+    ) -> list[bool] | None:
+        """Sparse Mamba state-snapshot retention.
+
+        A Mamba prefix-cache hit resumes the recurrent state from a *single*
+        cached state block at an ``alignment_tokens`` boundary (see
+        ``find_longest_cache_hit``). Caching the state at every block is what
+        lets a hit land at the finest granularity, but each snapshot is a full
+        recurrent state (one logical block, span >= 1) and dense retention can
+        dominate the KV pool at small block sizes — at ``block_size`` 128 a
+        per-block snapshot fills most of the pool, starving the allocator of
+        uncached blocks and forcing eviction of live attention prefixes.
+
+        ``retention_interval`` trades hit granularity for footprint by keeping
+        only one cached state per segment instead of one per block:
+
+          ``None`` -> dense (cache every block; default, unchanged behavior)
+          ``0``    -> keep only the latest replay boundary
+          ``> 0``  -> keep one state per ``retention_interval``-sized segment
+
+        A hit then resumes from the nearest retained boundary at or before the
+        shared prefix length (at most ``retention_interval`` tokens coarser),
+        which costs a little extra prefill but frees the intermediate snapshots
+        for reuse. ``retention_interval`` is validated to be a multiple of the
+        scheduler block size, so segment boundaries are always valid Mamba hit
+        boundaries.
+        """
+        if retention_interval is None or alignment_tokens is None:
+            # Dense caching (default) or no alignment constraint imposed.
+            return None
+        assert isinstance(kv_cache_spec, MambaSpec)
+        block_size = kv_cache_spec.block_size
+        mask = [False] * (end_block - start_block)
+
+        # (1) Segment-boundary states. A Mamba hit needs exactly the single
+        # state block ending on the boundary (no window, and draft models have
+        # no mamba layers, so no eagle shift). Block ``i`` ends at token
+        # ``(i + 1) * block_size``.
+        segment_tokens = None if retention_interval == 0 else retention_interval
+        if segment_tokens is not None:
+            per_segment = segment_tokens // block_size
+            if per_segment <= 1:
+                # Interval at/below the block size: every block is a boundary.
+                return None
+            for i in range(start_block, end_block):
+                if (i + 1) % per_segment == 0:
+                    mask[i - start_block] = True
+
+        # (2) Replay boundary. ``get_computed_blocks`` caps hits at
+        # ``num_prompt - 1``, so an exact prompt replay lands on the latest
+        # fine-aligned boundary. Sparse retention would otherwise skip its
+        # state, so keep it explicitly.
+        if num_prompt_tokens is not None:
+            latest = (num_prompt_tokens - 1) // alignment_tokens * alignment_tokens
+            boundary_block = latest // block_size - 1
+            if start_block <= boundary_block < end_block:
+                mask[boundary_block - start_block] = True
+
+        return mask
+
     def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
@@ -1218,7 +1312,9 @@ class MambaManager(SingleTypeKVCacheManager):
                     assert num_new_blocks <= 1
                 else:
                     assert num_new_blocks <= self.num_speculative_blocks + 1
-                new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+                new_blocks = self.block_pool.get_new_blocks(
+                    num_new_blocks, base_span=self._base_span
+                )
                 req_blocks.extend(new_blocks)
                 self._allocated_block_reqs.add(request_id)
                 return req_blocks[prev_block_len:]
@@ -1250,9 +1346,12 @@ class MambaManager(SingleTypeKVCacheManager):
             for block in self.req_to_blocks[request.request_id][
                 num_cached_blocks_before:num_cached_blocks_after
             ]:
-                if block.is_null:
+                # Skip null blocks (align-mode skipped states) and blocks that
+                # were not cached this step — with sparse retention
+                # (reachable_block_mask) the intermediate state snapshots carry
+                # no hash and must not be recorded as cached-this-step.
+                if block.is_null or block.block_hash is None:
                     continue
-                assert block.block_hash is not None
                 self.cached_blocks_this_step.add(block.block_hash)
 
     def new_step_starts(self) -> None:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -858,7 +858,7 @@ class KVCacheGroupSpec:
     # ``allocation_base_span`` consecutive base blocks from the shared address
     # space. The value is allocator-agnostic (a base-block count); the rounding
     # rule and how a multi-base-block allocation is realised are the
-    # allocator's concern (see ``KVCacheBlockAllocator.normalize_span``).
+    # allocator's concern (see ``BlockAllocator.normalize_span``).
     allocation_base_span: int = 1
 
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -849,6 +849,17 @@ class KVCacheGroupSpec:
     kv_cache_spec: KVCacheSpec
     # Whether this group contains EAGLE/MTP draft attention layers.
     is_eagle_group: bool = False
+    # Decoupled hybrid mode: how many base blocks one logical block of this
+    # group spans. 1 (the default) means one base block per logical block. For
+    # mamba in decoupled hybrid mode this is the allocator-*normalized* span:
+    # the natural footprint ceil(spec.page_size / base_page_bytes) rounded by
+    # the selected allocator to a granularity it can carve and align (the buddy
+    # allocator rounds up to a power of two). A mamba allocation then consumes
+    # ``allocation_base_span`` consecutive base blocks from the shared address
+    # space. The value is allocator-agnostic (a base-block count); the rounding
+    # rule and how a multi-base-block allocation is realised are the
+    # allocator's concern (see ``KVCacheBlockAllocator.normalize_span``).
+    allocation_base_span: int = 1
 
 
 @dataclass
@@ -858,10 +869,24 @@ class KVCacheConfig:
     """
 
     num_blocks: int
-    """The number of KV cache blocks"""
+    """The number of KV cache blocks.
+
+    In decoupled hybrid mode, this is the number of *base* blocks; one base
+    block is base_page_bytes bytes per layer-tuple slab. A logical block of
+    group g spans g.allocation_base_span base blocks.
+    """
     kv_cache_tensors: list[KVCacheTensor]
     """How should model runner initialize the KV cache tensors for each layer"""
     kv_cache_groups: list[KVCacheGroupSpec]
+    """The kv cache groups of the model."""
+    base_page_bytes: int | None = None
+    """When set: buddy-decoupled hybrid layout is in effect. Each tensor slab
+    is sized as num_blocks * base_page_bytes per layer, with first-dim stride
+    base_page_bytes. Each group's spec.page_size_bytes is the *logical* per-
+    block byte count (the kernel-visible size). The allocator hands out chunks
+    of group.allocation_base_span base blocks per logical block. When None:
+    legacy uniform-page layout (stride = spec.page_size_bytes /
+    page_size_padded)."""
     """
     The kv cache groups of the model.
     For models with only one type of attention, there is only one group that

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -378,3 +378,4 @@ def _compute_slot_mapping_kernel(
         slot_ids = block_numbers * block_size + local_block_offsets
         slot_ids = tl.where(is_local, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7070,6 +7070,12 @@ class GPUModelRunner(
         """
         kv_caches: dict[str, torch.Tensor] = {}
         has_attn, has_mamba = False, False
+        # In decoupled hybrid mode, the per-layer raw tensor is sized by
+        # base_page_bytes (the smallest group's page), not by spec.page_size_bytes.
+        # The kernel sees num_blocks base-units; one logical group block spans
+        # group.allocation_base_span base-units, but the kernel view's first-dim
+        # stride is base_page (so adjacent indices overlap for span > 1 groups).
+        base_page_bytes = getattr(self.kv_cache_config, "base_page_bytes", None)
         for group in self._kv_cache_spec_attn_group_iterator():
             kv_cache_spec = group.kv_cache_spec
             attn_backend = group.backend
@@ -7077,12 +7083,22 @@ class GPUModelRunner(
                 # There may be a last group for layers without kv cache.
                 continue
             kernel_block_size = kernel_block_sizes[group.kv_cache_group_id]
+            block_byte_stride = (
+                base_page_bytes
+                if base_page_bytes is not None
+                else kv_cache_spec.page_size_bytes
+            )
             for layer_name in group.layer_names:
                 if layer_name in self.runner_only_attn_layers:
                     continue
                 raw_tensor = kv_cache_raw_tensors[layer_name]
-                assert raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
-                num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
+                if base_page_bytes is not None:
+                    # Slab is padded by max-overhang for safe strided reads;
+                    # the logical block count is the config's num_blocks.
+                    num_blocks = self.kv_cache_config.num_blocks
+                else:
+                    assert raw_tensor.numel() % block_byte_stride == 0
+                    num_blocks = raw_tensor.numel() // block_byte_stride
                 if isinstance(kv_cache_spec, AttentionSpec):
                     has_attn = True
                     num_blocks_per_kv_block = (
@@ -7124,17 +7140,26 @@ class GPUModelRunner(
                     ]
 
                     raw_tensor = kv_cache_raw_tensors[layer_name].view(dtype)
-                    if kv_cache_spec.page_size_padded is not None:
-                        # Use strided view to handle page_size_bytes that
-                        # include padding. This follows
-                        # the same pattern as MambaSpec handling below.
+                    # Strided view is only needed when adjacent block indices
+                    # don't sit on adjacent kernel-block-sized strides in
+                    # memory: either (a) page-size padding inserts unused
+                    # bytes between blocks (`page_size_padded` set), or (b)
+                    # decoupled mode with span > 1 makes adjacent indices
+                    # overlap. For span == 1 attn groups under buddy, the
+                    # layout is contiguous and a plain .view() is correct (and
+                    # what baseline-attn uses outside buddy mode).
+                    needs_strided_view = kv_cache_spec.page_size_padded is not None or (
+                        base_page_bytes is not None
+                        and base_page_bytes < kv_cache_spec.page_size_bytes
+                    )
+                    if needs_strided_view:
                         # NOTE: This assumes kv_cache_shape[0] == num_blocks
                         # (i.e. the first physical dimension is the block
                         # index), which holds for MLA backends but NOT for
                         # standard attention backends whose shape starts with
                         # a K/V dimension of size 2.
                         dtype_size = get_dtype_size(dtype)
-                        page_stride = kv_cache_spec.page_size_bytes // dtype_size
+                        page_stride = block_byte_stride // dtype_size
                         strides = list(torch.empty(kv_cache_shape).stride())
                         strides[inv_order[0]] = page_stride
                         kv_cache = torch.as_strided(
@@ -7143,7 +7168,12 @@ class GPUModelRunner(
                             stride=tuple(strides),
                         )
                     else:
-                        # No padding — safe to use a contiguous view.
+                        # Contiguous view. Under buddy mode the slab may
+                        # have a max-overhang tail beyond what this group's
+                        # kernel view needs; trim before .view().
+                        view_numel = torch.Size(kv_cache_shape).numel()
+                        if raw_tensor.numel() != view_numel:
+                            raw_tensor = raw_tensor.narrow(0, 0, view_numel)
                         kv_cache = raw_tensor.view(kv_cache_shape)
                     kv_caches[layer_name] = kv_cache.permute(*inv_order)
 
@@ -7152,11 +7182,17 @@ class GPUModelRunner(
                     raw_tensor = kv_cache_raw_tensors[layer_name]
                     state_tensors = []
                     storage_offset_bytes = 0
+                    # In decoupled mode the per-block byte stride is base_page,
+                    # which is < page_size_bytes for mamba. Adjacent indices
+                    # overlap but only chunk-aligned ones are ever referenced.
+                    mamba_block_stride_bytes = (
+                        base_page_bytes
+                        if base_page_bytes is not None
+                        else kv_cache_spec.page_size_bytes
+                    )
                     for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
                         dtype_size = get_dtype_size(dtype)
-                        num_element_per_page = (
-                            kv_cache_spec.page_size_bytes // dtype_size
-                        )
+                        num_element_per_page = mamba_block_stride_bytes // dtype_size
                         target_shape = (num_blocks, *shape)
                         stride = torch.empty(target_shape).stride()
                         target_stride = (num_element_per_page, *stride[1:])

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -356,6 +356,9 @@ def prepare_kernel_block_sizes(
             continue
         if isinstance(kv_cache_spec, AttentionSpec):
             # This is an attention backend that supports virtual block splitting.
+            # Attention groups always allocate one base block per logical block
+            # (span 1) in decoupled hybrid mode, so kernel block sizing is the
+            # ordinary backend-driven split with no allocator-specific override.
             kv_manager_block_size = kv_cache_group.kv_cache_spec.block_size
             group_backends = [g.backend for g in attn_groups[kv_cache_gid]]
             selected_kernel_size = select_common_block_size(


### PR DESCRIPTION
## Purpose

**Experimental: a buddy-allocator-backed KV-cache free queue that enables _decoupled per-group page sizes_ for hybrid attention + Mamba models.**

Today, hybrid models must unify their KV-cache page size: `_align_hybrid_block_size` inflates the attention `block_size` up to Mamba's (much larger) native page so a single uniform-page block pool can serve both. That hurts prefix-cache granularity (attention can only hash at the inflated block size) and wastes memory.

This PR adds an opt-in path where **attention keeps its small, kernel-natural block size while Mamba keeps its native page size**, over a single shared *base-block* address space. A power-of-2 buddy allocator hands out variable-size chunks: an attention logical block = 1 base block (`chunk_order = 0`), a Mamba logical block = `2**chunk_order` consecutive base blocks (`chunk_order = ceil(log2(mamba_page / base_page))`).

Everything is gated behind environment flags and is **inert by default** — `VLLM_USE_BUDDY_BLOCK_POOL` is unset → existing `FreeKVCacheBlockQueue` / uniform-page behavior is unchanged.

### Flags
- `VLLM_USE_BUDDY_BLOCK_POOL=1` — swap the LRU free queue for the buddy queue and enable decoupled-page layout.
- `VLLM_BUDDY_MAX_ORDER=<k>` — largest buddy order (max chunk = `2**k` base blocks).
- `VLLM_BUDDY_GROUP_ORDERS=<csv>` — manual per-group order override (legacy testing path for attention specs).

## Changes

**New core data structures**
- `vllm/v1/core/buddy_block_pool.py` — `BuddyBlockPool`: a self-contained power-of-2 buddy allocator over a flat base-block id space (split/coalesce, per-order free sets). Building block; not wired into the manager directly.
- `vllm/v1/core/buddy_free_queue.py` — `BuddyFreeKVCacheBlockQueue`: a drop-in replacement for `FreeKVCacheBlockQueue` that maintains **one LRU doubly-linked list per buddy order** (threaded through the existing `prev/next_free_block` slots, so a block is in at most one queue). Key behaviors:
  - `alloc_chunk(order)` prefers splitting an **uncached** higher-order chunk over evicting a same-order **cached** one (uncached blocks link at the LRU head, cached at the tail → O(1) "any uncached at this order?" test).
  - `append(block)` eagerly coalesces with a free buddy, but **stops if either side holds a prefix-cache hash** so valid cache entries survive.
  - An `on_evict` callback drops the prefix-cache hash before a split/coalesce destroys a cached chunk's identity, letting prefix caching coexist with buddy mode.
  - Preserves the `NULL_BLOCK_ID = 0` invariant (first `popleft()` returns base id 0) and handles non-`2**max_order`-aligned tail blocks via a side fallback list.

**Block pool wiring** (`vllm/v1/core/block_pool.py`)
- Reads `VLLM_USE_BUDDY_BLOCK_POOL`; builds the buddy queue with the eviction callback when set.
- New `get_new_chunks(order, n)` / `free_chunks(...)` API (degrades to `get_new_blocks` for order 0 in legacy mode).

**Config / layout plumbing**
- `kv_cache_interface.py` — `KVCacheGroupSpec.chunk_order` and `KVCacheConfig.base_page_bytes` (set ⇒ decoupled layout in effect; tensor slabs sized as `num_blocks * base_page + max_overhang`).
- `kv_cache_utils.py` — in decoupled mode: skip page unification, anchor `base_page` to the smallest **attention** group's page, compute each group's `chunk_order`, size tensors with a tail overhang for safe strided reads, and shrink correctly while preserving the overhang. Prefix-cache hashing stays at attention's fine granularity.
- `platforms/interface.py` — `_align_hybrid_block_size` early-returns in decoupled mode: still sets `mamba_block_size` for the kernels, but does **not** inflate attention block size or pad Mamba's page.
- `single_type_kv_cache_manager.py` — managers allocate via `get_new_chunks(self._buddy_order, ...)`; published block ids are right-shifted by `order` so `BlockTable`'s hybrid-block expansion reconstructs the correct kernel rows.
- `worker/utils.py` — `prepare_kernel_block_sizes` forces `kernel_block_size = block_size >> order` for ordered groups.
- `worker/gpu_model_runner.py` — KV tensor reshape uses `base_page_bytes` as the first-dim byte stride; uses a strided view when `chunk_order > 0` (adjacent indices overlap) and trims the overhang tail for the contiguous-view case.

**Tests + docs**
- `tests/v1/core/test_buddy_block_pool.py` — 28 tests covering the allocator and the LRU free-queue adapter (split chains, coalescing, OOM, cached-eviction policy, `NULL_BLOCK_ID=0`, non-overlap).
- `tests/v1/worker/test_variable_block_slot_mapping.py` — slot-mapping correctness for `chunk_order > 0`, pad regions, multi-request.
- `buddy_allocator_explained.html` — standalone visual explainer of the design.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/core/test_buddy_block_pool.py -v
.venv/bin/python -m pytest tests/v1/worker/test_variable_block_slot_mapping.py -v
# Regression (buddy mode off by default):
.venv/bin/python -m pytest tests/v1/core/ -q
```

End-to-end smoke for a hybrid model with the flags set:

```bash
VLLM_USE_BUDDY_BLOCK_POOL=1 VLLM_BUDDY_MAX_ORDER=<k> \
  .venv/bin/python -m vllm.entrypoints.openai.api_server --model <hybrid-mamba-model>
```

## Test Result

<!-- Paste unit-test output and before/after correctness / memory comparison for the hybrid model here. -->

## Notes

- **Experimental / opt-in.** With `VLLM_USE_BUDDY_BLOCK_POOL` unset, the diff is behavior-preserving (the old `FreeKVCacheBlockQueue` and uniform-page path are taken).
- True memory savings require unifying the per-group cache tensors; current managers still index per-base-id and waste the trailing `2**order - 1` ids of each chunk in their per-group tensor. That unification is a follow-up.
- AI assistance (Claude) was used to author this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
